### PR TITLE
fix(ui): fix site header icon

### DIFF
--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -27,7 +27,7 @@ export function SiteHeader({
 						className="me-auto fill-[#0B263F] dark:fill-white"
 						href={ROUTES.USER_DASHBOARD}
 					>
-						<AppLogo className="h-6 w-fit" />
+						<AppLogo className="h-6 w-fit max-w-32" />
 					</Link>
 					<ThemeToggle variant={"outline"} />
 					<SignOut />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the SiteHeader logo sizing by capping AppLogo to max-w-32 so it doesn’t stretch or overflow in the header.

<sup>Written for commit a34920c00a7eae1b189ebfc0f7828778e851ea9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

