### PR TITLE
chore: implement release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,23 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        id: release
+        with:
+          config-file: release-please-config.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "spesen-tool",
-	"version": "0.1.0",
+	"version": "0.0.1-alpha.1",
 	"private": true,
 	"type": "module",
 	"scripts": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+	"packages": {
+		".": {
+			"release-type": "node",
+			"package-name": "spesen-tool",
+			"version-file": "package.json",
+			"changelog-path": "CHANGELOG.md",
+			"extra-files": []
+		}
+	},
+	"$versioning-strategy": "always-bump-patch"
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set up release-please to automate releases, changelog generation, and version bumps on pushes to main/master. Initialized the package version to 0.0.1-alpha.1.

- **New Features**
  - Added GitHub Action (.github/workflows/release-please.yml) using google-github-actions/release-please-action@v4.
  - Configured node release type in release-please-config.json (version sourced from package.json, changelog at CHANGELOG.md, always bump patch).
  - Action triggers on push to main/master and writes release PRs and tags.

<sup>Written for commit 0043b6a3692664e824a019cfe6c2e11f6c99d88a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

