### PR TITLE
fix(expense): amount field for receipt expense

### DIFF
--- a/src/components/forms/expense/receipt.tsx
+++ b/src/components/forms/expense/receipt.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { NumberField } from "@base-ui/react";
 import { useUploadFiles } from "@better-upload/client";
 import { useForm } from "@tanstack/react-form";
 import { formatDate } from "date-fns";
@@ -16,6 +17,11 @@ import {
 	FieldGroup,
 	FieldLabel,
 } from "@/components/ui/field";
+import {
+	InputGroup,
+	InputGroupAddon,
+	InputGroupInput,
+} from "@/components/ui/input-group";
 import { Textarea } from "@/components/ui/textarea";
 import { UploadDropzone } from "@/components/ui/upload-dropzone";
 import { formatBytes, renameFileWithHash } from "@/lib/utils";
@@ -168,6 +174,51 @@ export function CreateReceiptExpenseForm({
 						);
 					}}
 					name="endDate"
+				/>
+				<form.Field
+					children={(field) => {
+						const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
+						return (
+							<Field className="md:col-span-2" data-invalid={isInvalid}>
+								<FieldLabel htmlFor={field.name}>Betrag</FieldLabel>
+								<NumberField.Root
+									format={{
+										style: "decimal",
+										minimumFractionDigits: 2,
+										maximumFractionDigits: 2,
+									}}
+									locale={"de-DE"}
+									onValueChange={(value) => field.handleChange(value ?? 0)}
+									value={field.state.value}
+								>
+									<NumberField.Group>
+										<InputGroup className="overflow-hidden opacity-100!">
+											<NumberField.Input
+												render={
+													<InputGroupInput
+														aria-invalid={isInvalid}
+														autoComplete="off"
+														id={field.name}
+														inputMode="decimal"
+														name={field.name}
+														placeholder="0,00"
+													/>
+												}
+											/>
+											<InputGroupAddon
+												align={"inline-end"}
+												className="flex w-8 items-center justify-center overflow-hidden border-l bg-muted p-2"
+											>
+												<span>€</span>
+											</InputGroupAddon>
+										</InputGroup>
+									</NumberField.Group>
+								</NumberField.Root>
+								{isInvalid && <FieldError errors={field.state.meta.errors} />}
+							</Field>
+						);
+					}}
+					name="amount"
 				/>
 				<form.Field
 					children={(field) => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the amount input in the receipt expense form by replacing the plain input with a localized number field. The field enforces two decimals, shows a € suffix, and hooks into form validation to prevent invalid values.

<sup>Written for commit eb8cd716883f5807b077d290e5b3541154f5181f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

