### PR TITLE
feat(api): restrict expense creation

### DIFF
--- a/src/app/(app)/reports/[id]/_components/report-expenses-list.tsx
+++ b/src/app/(app)/reports/[id]/_components/report-expenses-list.tsx
@@ -12,6 +12,7 @@ import {
 	EmptyMedia,
 	EmptyTitle,
 } from "@/components/ui/empty";
+import { ReportStatus } from "@/generated/prisma/enums";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/react";
 import { ReportExpenseCard } from "./report-expense-card";
@@ -19,8 +20,16 @@ import { ReportExpenseCard } from "./report-expense-card";
 export function ReportExpensesList({
 	className,
 	reportId,
+	reportStatus,
 	...props
-}: React.ComponentProps<"ul"> & { reportId: string }) {
+}: React.ComponentProps<"ul"> & {
+	reportId: string;
+	reportStatus: ReportStatus;
+}) {
+	const canAddExpense =
+		reportStatus === ReportStatus.DRAFT ||
+		reportStatus === ReportStatus.NEEDS_REVISION;
+
 	const [expenses] = api.expense.listForReport.useSuspenseQuery({
 		reportId: reportId,
 	});
@@ -39,6 +48,10 @@ export function ReportExpensesList({
 				</EmptyHeader>
 				<EmptyContent className="flex-row justify-center gap-2">
 					<Button
+						className={
+							"data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 sm:w-fit"
+						}
+						data-disabled={!canAddExpense}
 						nativeButton={false}
 						render={
 							<Link href={`/reports/${reportId}/expenses/new`}>
@@ -47,6 +60,7 @@ export function ReportExpensesList({
 							</Link>
 						}
 						size="sm"
+						tabIndex={!canAddExpense ? 0 : -1}
 					/>
 				</EmptyContent>
 			</Empty>

--- a/src/server/api/routers/expense.ts
+++ b/src/server/api/routers/expense.ts
@@ -1,6 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
-import { ExpenseType } from "@/generated/prisma/enums";
+import { ExpenseType, ReportStatus } from "@/generated/prisma/enums";
 import {
 	createFoodExpenseSchema,
 	createReceiptExpenseSchema,
@@ -68,6 +68,7 @@ export const expenseRouter = createTRPCRouter({
 				where: { id: input.reportId },
 				select: {
 					ownerId: true,
+					status: true,
 				},
 			});
 
@@ -75,6 +76,16 @@ export const expenseRouter = createTRPCRouter({
 				throw new TRPCError({
 					code: "NOT_FOUND",
 					message: "Report not found",
+				});
+			}
+
+			if (
+				report.status !== ReportStatus.DRAFT &&
+				report.status !== ReportStatus.NEEDS_REVISION
+			) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "You can only add expenses to draft or needs revision reports",
 				});
 			}
 
@@ -121,6 +132,7 @@ export const expenseRouter = createTRPCRouter({
 				where: { id: input.reportId },
 				select: {
 					ownerId: true,
+					status: true,
 				},
 			});
 
@@ -128,6 +140,16 @@ export const expenseRouter = createTRPCRouter({
 				throw new TRPCError({
 					code: "NOT_FOUND",
 					message: "Report not found",
+				});
+			}
+
+			if (
+				report.status !== ReportStatus.DRAFT &&
+				report.status !== ReportStatus.NEEDS_REVISION
+			) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "You can only add expenses to draft or needs revision reports",
 				});
 			}
 
@@ -180,6 +202,7 @@ export const expenseRouter = createTRPCRouter({
 				where: { id: input.reportId },
 				select: {
 					ownerId: true,
+					status: true,
 				},
 			});
 
@@ -187,6 +210,16 @@ export const expenseRouter = createTRPCRouter({
 				throw new TRPCError({
 					code: "NOT_FOUND",
 					message: "Report not found",
+				});
+			}
+
+			if (
+				report.status !== ReportStatus.DRAFT &&
+				report.status !== ReportStatus.NEEDS_REVISION
+			) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "You can only add expenses to draft or needs revision reports",
 				});
 			}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restricts expense creation to reports in Draft or Needs revision and owned by the user. The UI disables “Add expense” when a report isn’t editable, and the API now enforces the same rule.

- **New Features**
  - API: Reject expense creation if report status is not Draft or Needs revision (BAD_REQUEST) and still enforce owner check (FORBIDDEN).
  - UI: Disable “Ausgabe hinzufügen” buttons when not allowed; reflect state with styles and tab behavior.
  - Page: Fetch report to derive editability; pass reportStatus to the expenses list.

<sup>Written for commit 49b58698d45d3a2ca681e5fec5c67aedcb20d5ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

