### PR TITLE
fix(api): update report update route

### DIFF
--- a/src/server/api/routers/report.tsx
+++ b/src/server/api/routers/report.tsx
@@ -186,7 +186,7 @@ export const reportRouter = createTRPCRouter({
 				id: z.string(),
 				title: z.string().min(1).optional(),
 				description: z.string().optional(),
-				businessUnit: z.string().min(1).optional(),
+				businessUnitId: z.string().min(1).optional(),
 				accountingUnitId: z.string().min(1).optional(),
 				status: z.enum(ReportStatus).optional(),
 			}),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the report update API to accept businessUnitId instead of businessUnit. This aligns the route with the report schema and avoids validation mismatches when updating business unit references.

<sup>Written for commit 8b722d87cfa4d5a6b68f06f04f4d9ea00397ac4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

