### PR TITLE
chore(release-please): alpha releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,4 +20,5 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          release-type: simple
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,8 +6,10 @@
 			"package-name": "spesen-tool",
 			"version-file": "package.json",
 			"changelog-path": "CHANGELOG.md",
-			"extra-files": []
+			"extra-files": [],
+			"prerelease": true,
+			"prerelease-type": "alpha",
+			"versioning-strategy": "always-bump-patch"
 		}
-	},
-	"$versioning-strategy": "always-bump-patch"
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable alpha prereleases with release-please for spesen-tool. The workflow now uses a config and manifest, always bumping patch for early testing without stable releases.

- **New Features**
  - Configure alpha prereleases (prerelease: true, type: alpha, always bump patch).
  - Use release-please config-file and manifest-file in the GitHub Action.

<sup>Written for commit 6708356bcb4305595d65ef002dce98a6ac2efc48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

