### PR TITLE
fix(ui): padding on auth layout

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -2,7 +2,7 @@ import { AuthForm } from "@/components/forms/auth-form";
 
 export default async function ServerPage() {
 	return (
-		<main className="flex min-h-svh w-full items-center justify-center">
+		<main className="container flex min-h-svh w-full items-center justify-center">
 			<div>
 				<h1 className="font-medium text-foreground text-xl">Willkommen zurück!</h1>
 				<p className="mt-2 text-muted-foreground text-sm">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add container class to the auth page layout to restore standard horizontal padding and width constraints. This prevents edge-to-edge content on small screens and aligns the page with the app’s grid.

<sup>Written for commit 2099d97bd4246eaf1b09089a3703871e63dfb43b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

