### PR TITLE
docs: implement base documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,40 @@
+# Spesen Tool Documentation
+
+Welcome to the official documentation for the **Spesen Tool**, a modern expense management platform built for student initiatives.
+
+## Project Overview
+
+The Spesen Tool simplifies the process of submitting, reviewing, and managing expense reports. It is designed to be efficient, type-safe, and easy to deploy.
+
+### Key Features
+
+- **Expense Reporting**: Create reports with multiple expenses (Receipts, Travel, Food).
+- **Workflow Management**: Draft, submit, and review reports with clear status transitions.
+- **Admin Dashboard**: Comprehensive tools for reviewers to manage users, cost units, and allowances.
+- **Cost Unit Tracking**: Organize expenses by specific projects or accounting units.
+- **Automated Notifications**: Email alerts for status changes and submissions via Resend.
+- **Secure Authentication**: Microsoft Azure AD integration for organizational sign-in.
+- **File Attachments**: Secure receipt uploads to S3-compatible storage.
+
+## Tech Stack
+
+- **Framework**: [Next.js 15+](https://nextjs.org/) (App Router)
+- **API**: [tRPC](https://trpc.io/) for end-to-end type safety
+- **Database**: [PostgreSQL](https://www.postgresql.org/) with [Prisma ORM](https://www.prisma.io/)
+- **Auth**: [Better-Auth](https://www.better-auth.com/)
+- **Styling**: [Tailwind CSS](https://tailwindcss.com/) & [Lucide React](https://lucide.dev/)
+- **Forms**: [TanStack Form](https://tanstack.com/form)
+- **Emails**: [React Email](https://react.email/) & [Resend](https://resend.com/)
+
+## Documentation Index
+
+1. [**Getting Started**](getting-started.md) - Installation and quick start guide.
+2. [**System Architecture**](architecture.md) - Overview of the design and data flow.
+3. [**Configuration**](configuration.md) - Environment variables and setup guides.
+4. [**API Reference**](api-reference.md) - Documentation of tRPC routers and endpoints.
+5. [**Database Schema**](database-schema.md) - Models, relationships, and ER diagram.
+6. [**Deployment**](deployment.md) - Production build and Docker instructions.
+
+---
+
+*This project is under active development. For contributions, please see [CONTRIBUTING.md](../CONTRIBUTING.md).*

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,101 @@
+# API Reference (tRPC)
+
+The Spesen Tool uses [tRPC](https://trpc.io/) to provide a type-safe API for both client and server.
+
+## Overview
+
+The API is structured into several routers, each handling a specific domain of the application. The root router is located at `src/server/api/root.ts`.
+
+### Base URL
+All tRPC requests are handled at the `/api/trpc` endpoint.
+
+---
+
+## Routers
+
+### `report`
+Handles the lifecycle of expense reports.
+- **`create`**: Create a new report draft.
+- **`submit`**: Submit a draft report for review.
+- **`getById`**: Fetch a specific report with its expenses.
+- **`listOwn`**: List reports owned by the current user.
+- **`delete`**: Remove a draft report.
+
+### `expense`
+Manages individual expenses within a report.
+- **`add`**: Add an expense (Receipt, Travel, or Food) to a report.
+- **`update`**: Modify an existing expense.
+- **`delete`**: Remove an expense from a report.
+- **`listByReportId`**: Fetch all expenses for a given report.
+
+### `admin`
+Privileged operations for reviewers and superusers.
+- **`listPending`**: List all reports awaiting approval.
+- **`review`**: Approve or reject a report.
+- **`listUsers`**: Manage system users.
+- **`updateSettings`**: Update global settings like kilometer rates or deductions.
+
+### `costUnit`
+Management of accounting units and groups.
+- **`list`**: Fetch all available cost units.
+- **`create`**: Add a new cost unit.
+- **`createGroup`**: Create a category for cost units.
+
+### `user`
+User-specific settings and preferences.
+- **`getMe`**: Fetch the current user's profile and roles.
+- **`updatePreferences`**: Change notification settings.
+
+---
+
+## Usage Examples
+
+### Client-side (React)
+
+Using the `api` hook from `src/trpc/react.tsx`:
+
+```tsx
+import { api } from "@/trpc/react";
+
+function CreateReportButton() {
+  const createReport = api.report.create.useMutation({
+    onSuccess: (report) => {
+      console.log("Report created:", report.id);
+    },
+  });
+
+  return (
+    <button onClick={() => createReport.mutate({ title: "Business Trip" })}>
+      New Report
+    </button>
+  );
+}
+```
+
+### Server-side (Server Components)
+
+Using the `api` caller from `src/trpc/server.ts`:
+
+```tsx
+import { api } from "@/trpc/server";
+
+export default async function ReportsPage() {
+  const reports = await api.report.listOwn.query();
+
+  return (
+    <ul>
+      {reports.map(report => (
+        <li key={report.id}>{report.title}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+## Error Handling
+
+The API uses standard tRPC error codes:
+- `UNAUTHORIZED`: When a user is not logged in.
+- `FORBIDDEN`: When a user lacks the required role (e.g., trying to access `admin` routes).
+- `NOT_FOUND`: When a requested resource does not exist.
+- `BAD_REQUEST`: When input validation (Zod) fails.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,84 @@
+# System Architecture
+
+The Spesen Tool is a full-stack Next.js application built with a focus on type safety and developer productivity.
+
+## High-Level Overview
+
+The following diagram illustrates the core components and their interactions:
+
+```mermaid
+flowchart TD
+    subgraph Client [Client Side]
+        UI[React UI / Tailwind]
+        TQuery[TanStack Query]
+        TForm[TanStack Form]
+    end
+
+    subgraph Server [Next.js Server]
+        TRPC[tRPC Router]
+        Auth[Better-Auth]
+        Prisma[Prisma ORM]
+        PDF[PDF Generator]
+    end
+
+    subgraph External [External Services]
+        DB[(PostgreSQL)]
+        Azure[Azure AD]
+        Resend[Resend Email]
+        S3[S3 Storage]
+    end
+
+    UI --> TQuery
+    TQuery --> TRPC
+    TRPC --> Auth
+    TRPC --> Prisma
+    TRPC --> PDF
+    Auth --> Azure
+    Prisma --> DB
+    TRPC --> Resend
+    TRPC --> S3
+```
+
+## Frontend Architecture
+
+### Next.js App Router
+The application uses the Next.js App Router for server-side rendering, streaming, and efficient navigation. Pages are located in `src/app`.
+
+### tRPC Client
+All data fetching and mutations are performed via tRPC, providing end-to-end type safety. The client configuration is in `src/trpc`.
+
+### Form Management
+[TanStack Form](https://tanstack.com/form) is used for complex forms like expense report creation, ensuring validation and type safety across fields.
+
+### Styling
+[Tailwind CSS](https://tailwindcss.com/) is used for styling, with components based on a custom UI library built on [Base UI](https://base-ui.com/).
+
+## Backend Architecture
+
+### tRPC Server
+The API layer is built with tRPC. Routers are organized by domain in `src/server/api/routers`. The root router is defined in `src/server/api/root.ts`.
+
+### Authentication
+[Better-Auth](https://www.better-auth.com/) handles authentication, specifically integrated with Microsoft Azure AD. Sessions are stored in the PostgreSQL database.
+
+### Database (Prisma)
+[Prisma](https://www.prisma.io/) serves as the ORM, providing a type-safe interface to the PostgreSQL database. The schema is defined in `prisma/schema.prisma`.
+
+### External Services
+- **Storage**: Receipts and attachments are stored in S3-compatible storage using `@better-upload`.
+- **Email**: Notifications are sent via [Resend](https://resend.com/) using [React Email](https://react.email/) templates found in `src/components/emails`.
+
+## Core Workflows
+
+### Expense Report Lifecycle
+
+1. **Draft**: User creates a report and adds expenses. Only visible to the owner.
+2. **Pending Approval**: User submits the report. It becomes visible to admins/reviewers.
+3. **Review**: Admins can approve, reject, or request revisions.
+4. **Finalized**: Once accepted or rejected, the report status is updated, and the user is notified.
+
+### Configuration System
+The app uses a dual configuration system:
+- `config.ts`: Non-sensitive settings (URLs, IDs).
+- `.env`: Sensitive secrets (API keys, passwords).
+Both are validated against a Zod schema in `src/lib/config/schema.ts`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,90 @@
+# Configuration Guide
+
+The Spesen Tool uses a two-tier configuration system designed for security and flexibility.
+
+## Configuration Tiers
+
+### 1. Config File (`config.ts`)
+Used for non-sensitive settings that vary between environments but are not secrets. This file can be version-controlled or mounted in a container.
+- **Path**: Root of the project (`/config.ts`).
+- **Template**: `config.example.ts`.
+- **Validation**: Checked against `configSchema` in `src/lib/config/schema.ts`.
+
+### 2. Environment Variables (`.env`)
+Used for sensitive secrets and system-level overrides.
+- **Path**: Root of the project (`/.env`).
+- **Template**: `.env.example`.
+
+---
+
+## Configuration Reference
+
+### Application Settings (`app`)
+
+| Config Key | Env Variable | Required | Description |
+|------------|--------------|----------|-------------|
+| `app.name` | - | No | Name displayed in UI. Default: "Spesen Tool" |
+| `app.url` | `BETTER_AUTH_URL` | **Yes** | Public URL of the app (e.g., `https://expenses.example.com`) |
+| `app.superuserId` | `SUPERUSER_ID` | **Yes** | The `userId` of the primary administrator |
+
+### Database Settings (`database`)
+
+| Config Key | Env Variable | Required | Description |
+|------------|--------------|----------|-------------|
+| `database.url` | `DATABASE_URL` | **Yes** | PostgreSQL connection string |
+| `database.logging` | - | No | Prisma log levels (e.g., `["query", "error"]`) |
+
+### Authentication Settings (`auth`)
+
+| Config Key | Env Variable | Required | Description |
+|------------|--------------|----------|-------------|
+| `auth.microsoft.clientId` | `MICROSOFT_CLIENT_ID` | **Yes** | Azure AD Application (client) ID |
+| `auth.microsoft.tenantId` | `MICROSOFT_TENANT_ID` | **Yes** | Azure AD Tenant ID |
+| - | `MICROSOFT_CLIENT_SECRET` | **Yes** | Azure AD Client Secret (Secret) |
+| - | `BETTER_AUTH_SECRET` | **Yes** | JWT signing secret for Better-Auth |
+
+### Storage Settings (`storage`)
+
+| Config Key | Env Variable | Required | Description |
+|------------|--------------|----------|-------------|
+| `storage.host` | `STORAGE_HOST` | **Yes** | S3-compatible host (e.g., `s3.amazonaws.com`) |
+| `storage.region` | `STORAGE_REGION` | **Yes** | S3 region (e.g., `eu-central-1`) |
+| `storage.bucket` | `STORAGE_BUCKET` | **Yes** | Name of the bucket for uploads |
+| - | `STORAGE_ACCESS_KEY_ID` | **Yes** | S3 Access Key ID (Secret) |
+| - | `STORAGE_ACCESS_KEY` | **Yes** | S3 Secret Access Key (Secret) |
+
+### Email Settings (`email`)
+
+| Config Key | Env Variable | Required | Description |
+|------------|--------------|----------|-------------|
+| `email.from` | `EMAIL_FROM` | **Yes** | Sender email address |
+| `email.replyTo` | - | No | Reply-to email address |
+| - | `RESEND_API_KEY` | **Yes** | API key for Resend service (Secret) |
+
+---
+
+## External Service Setup
+
+### 1. Microsoft Azure AD
+1. Register a new app in [Azure Portal](https://portal.azure.com) > App Registrations.
+2. Set Redirect URI: `https://YOUR_DOMAIN/api/auth/callback/microsoft`.
+3. Add `User.Read` API permission (delegated).
+4. Create a Client Secret and save it.
+
+### 2. S3-compatible Storage (e.g., AWS S3, MinIO)
+1. Create a bucket.
+2. Ensure the bucket has appropriate CORS settings if files are accessed directly from the browser.
+3. Create an IAM user/service account with `s3:PutObject`, `s3:GetObject`, and `s3:DeleteObject` permissions.
+
+### 3. Resend (Email)
+1. Create an account at [Resend](https://resend.com).
+2. Verify your sending domain.
+3. Create an API key.
+
+## Validation
+
+You can validate your configuration at any time by running:
+```bash
+pnpm config:validate
+```
+This will check for missing required fields and invalid formats (URLs, emails, etc.).

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -1,0 +1,81 @@
+# Database Schema
+
+The Spesen Tool uses PostgreSQL as its primary database. The schema is managed via Prisma.
+
+## Entity-Relationship Diagram
+
+```mermaid
+erDiagram
+    User ||--o{ Report : "owns"
+    User ||--o{ Session : "has"
+    User ||--o{ Account : "linked to"
+    User ||--o| Preferences : "sets"
+    
+    Report ||--o{ Expense : "contains"
+    Report }|--|| CostUnit : "assigned to"
+    
+    Expense ||--o{ Attachment : "has"
+    
+    CostUnit }|--o| CostUnitGroup : "belongs to"
+    
+    Settings ||--|| User : "singleton"
+```
+
+## Core Models
+
+### `Report`
+Represents an expense report containing one or more expenses.
+- `id`: Unique identifier (CUID).
+- `title`: Short descriptive name.
+- `status`: Lifecycle state (`DRAFT`, `PENDING_APPROVAL`, `NEEDS_REVISION`, `ACCEPTED`, `REJECTED`).
+- `ownerId`: Relation to the `User` who created it.
+- `costUnitId`: Relation to the `CostUnit` this report is billed against.
+
+### `Expense`
+Individual line items within a report.
+- `type`: Category (`RECEIPT`, `TRAVEL`, `FOOD`).
+- `amount`: Monetary value.
+- `startDate` / `endDate`: Time range for the expense.
+- `meta`: JSON field storing type-specific metadata (e.g., travel distance, meal deductions).
+
+### `CostUnit` & `CostUnitGroup`
+Used to categorize expenses for accounting purposes.
+- `tag`: Unique short code (e.g., "PRJ-2024").
+- `title`: Human-readable name.
+- `examples`: List of common items for this cost unit.
+
+### `User`
+User profiles and roles.
+- `role`: Access level (`user`, `admin`).
+- `banned`: Flag for disabling access.
+
+## Authentication Models (Better-Auth)
+These models are required and managed by Better-Auth:
+- `Session`: Active user sessions.
+- `Account`: Linked OAuth accounts (Microsoft Azure AD).
+- `Verification`: Tokens for email verification or other flows.
+
+## Global Models
+
+### `Settings`
+A singleton model storing global configuration parameters:
+- `kilometerRate`: Default rate for travel expenses.
+- `dailyFoodAllowance`: Standard allowance for meals.
+- `reviewerEmail`: Global contact for report reviews.
+
+### `Preferences`
+User-specific UI and notification settings.
+
+## Enums
+
+### `ReportStatus`
+- `DRAFT`: Still being edited by the owner.
+- `PENDING_APPROVAL`: Submitted and waiting for reviewer action.
+- `NEEDS_REVISION`: Reviewer sent it back for changes.
+- `ACCEPTED`: Approved for reimbursement.
+- `REJECTED`: Declined by reviewer.
+
+### `ExpenseType`
+- `RECEIPT`: Physical or digital receipts for purchases.
+- `TRAVEL`: Mileage or transport costs.
+- `FOOD`: Daily allowance (Per Diem) for meals.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,93 @@
+# Deployment Guide
+
+This guide covers the steps to deploy the Spesen Tool in a production environment.
+
+## Production Strategy
+
+The Spesen Tool is designed to be deployed as a Docker container. Next.js is configured for [standalone output](https://nextjs.org/docs/app/api-reference/next-config-js/output#standalone), which minimizes the final image size.
+
+## Prerequisites
+
+- **Docker & Docker Compose**: The recommended way to run the application and its database.
+- **PostgreSQL**: A production-ready instance (can be run via Docker).
+- **S3 Storage**: AWS S3, MinIO, or similar for file uploads.
+- **SMTP/Email**: An account with [Resend](https://resend.com).
+- **Microsoft Azure AD**: For user authentication.
+
+---
+
+## Deployment Steps
+
+### 1. Build the Application
+If you are building the image yourself:
+```bash
+docker build -t spesen-tool .
+```
+*Note: Ensure `SKIP_ENV_VALIDATION=1` is set during the build process if secrets are not available.*
+
+### 2. Configure Production Secrets
+Ensure all required environment variables are set in your deployment environment. See the [Configuration Guide](configuration.md) for a full list.
+
+### 3. Database Migrations
+Before starting the application, run the migrations against your production database:
+```bash
+pnpm db:migrate
+```
+
+### 4. Running with Docker Compose
+A typical production `docker-compose.yml` might look like this:
+
+```yaml
+services:
+  app:
+    image: spesen-tool
+    ports:
+      - "3000:3000"
+    env_file: .env.prod
+    volumes:
+      - ./config.ts:/app/config.ts:ro
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:16-alpine
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: spesen_tool
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d spesen_tool"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata:
+```
+
+---
+
+## Post-Deployment Checklist
+
+1. **Verify Connectivity**: Ensure the app can reach PostgreSQL, S3, and Resend.
+2. **Initial Admin**: Log in and verify that your `SUPERUSER_ID` has access to the `/admin` routes.
+3. **CORS & Redirects**: Check that your Azure AD Redirect URI matches your production domain.
+4. **SSL/TLS**: Ensure the application is served over HTTPS. If using a reverse proxy (like Nginx), pass the `X-Forwarded-Proto` header.
+5. **Backups**: Schedule regular backups for your PostgreSQL database and S3 bucket.
+
+## Troubleshooting
+
+### Build Fails with "Invalid Environment Variables"
+If your build fails because secrets are missing, ensure `SKIP_ENV_VALIDATION=1` is set in your Dockerfile or build environment.
+
+### Emails Not Sending
+1. Check that your `RESEND_API_KEY` is valid.
+2. Ensure the `EMAIL_FROM` address is verified in your Resend dashboard.
+
+### File Uploads Failing
+1. Verify S3 credentials and bucket name.
+2. Check that the `STORAGE_REGION` and `STORAGE_HOST` are correct.
+3. If using MinIO, set `storage.forcePathStyle: true` in `config.ts`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,86 @@
+# Getting Started
+
+Follow this guide to set up the Spesen Tool for local development.
+
+## Prerequisites
+
+Before you begin, ensure you have the following installed:
+
+- **Node.js**: Version specified in `.nvmrc` (LTS recommended). We suggest using [nvm](https://github.com/nvm-sh/nvm).
+- **pnpm**: Version specified in `package.json` (managed via Corepack).
+- **Docker**: For running the local PostgreSQL database.
+- **Git**: For version control.
+
+## Installation
+
+1. **Clone the Repository**
+   ```bash
+   git clone https://github.com/move-ev/spesen-tool.git
+   cd spesen-tool
+   ```
+
+2. **Set Node.js Version**
+   ```bash
+   nvm install
+   nvm use
+   ```
+
+3. **Install Dependencies**
+   ```bash
+   pnpm install
+   ```
+
+## Development Environment Setup
+
+1. **Configure Environment Variables**
+   Copy the example environment file and fill in your values:
+   ```bash
+   cp .env.example .env
+   ```
+   *Note: For a quick start, you only need the `DATABASE_URL` if you just want to run the database. See [Configuration](configuration.md) for a full list of variables.*
+
+2. **Start the Database**
+   The project includes a `docker-compose.yml` for a local PostgreSQL instance:
+   ```bash
+   docker compose up -d
+   ```
+
+3. **Initialize the Database**
+   Run the migrations and generate the Prisma client:
+   ```bash
+   pnpm db:generate
+   ```
+
+4. **Start the Development Server**
+   ```bash
+   pnpm dev
+   ```
+   The application will be available at [http://localhost:3000](http://localhost:3000).
+
+## Initial Admin Setup
+
+Once the app is running, you'll need to create an admin user:
+
+1. Sign in via Microsoft (ensure your Azure AD is configured in `.env`).
+2. After your first sign-in, find your `userId` in the `User` table (use `pnpm db:studio` to browse the database).
+3. Update your `config.ts` (or `SUPERUSER_ID` env var) with this ID:
+   ```typescript
+   // config.ts
+   app: {
+     superuserId: "your-user-id-here",
+     // ...
+   }
+   ```
+4. Restart the app. You should now have access to the Admin dashboard.
+
+## Common Commands
+
+| Command | Description |
+|---------|-------------|
+| `pnpm dev` | Start development server |
+| `pnpm build` | Build for production |
+| `pnpm start` | Start production server |
+| `pnpm db:studio` | Open Prisma Studio to view data |
+| `pnpm db:migrate` | Apply database migrations |
+| `pnpm check` | Run linting and formatting checks (Biome) |
+| `pnpm typecheck` | Run TypeScript compiler checks |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added the base documentation for Spesen Tool, including a README index and guides for getting started, architecture, API, configuration, database schema, and deployment. This improves onboarding and makes local setup and production deployment straightforward.

<sup>Written for commit 58eaf22e09781797f88419f3ff081e33fa91ff4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

