### PR TITLE
feat(web): implement direct receipt views

### DIFF
--- a/src/app/(app)/reports/[id]/_components/report-expense-card.tsx
+++ b/src/app/(app)/reports/[id]/_components/report-expense-card.tsx
@@ -5,12 +5,14 @@ import { formatDate } from "date-fns";
 import {
 	CarIcon,
 	EllipsisVerticalIcon,
+	ExternalLinkIcon,
 	InfoIcon,
 	PencilIcon,
 	ReceiptIcon,
 	Trash2Icon,
 	UtensilsIcon,
 } from "lucide-react";
+import Link from "next/link";
 import React from "react";
 import { toast } from "sonner";
 import { ExpenseDetails } from "@/app/(app)/admin/_components/expense-details";
@@ -59,7 +61,7 @@ export function ReportExpenseCard({
 	reportStatus,
 	...props
 }: React.ComponentProps<typeof Card> & {
-	expense: ClientExpense & { attachments: Partial<Attachment>[] };
+	expense: ClientExpense & { attachments: Attachment[] };
 	reportStatus?: ReportStatus;
 }) {
 	const [detailsOpen, setDetailsOpen] = React.useState(false);
@@ -146,6 +148,25 @@ export function ReportExpenseCard({
 						label="Datum"
 						value={formatDate(expense.startDate, "dd.MM.yyyy")}
 					/>
+					{expense.type === "RECEIPT" && expense.attachments.length > 0 ? (
+						<div className="space-y-2 pt-4">
+							<p className="font-medium text-muted-foreground text-xs">Belege</p>
+							<div className="flex flex-col gap-2">
+								{expense.attachments.map((attachment, index) => (
+									<Link
+										className="flex items-center justify-start gap-2 font-medium text-primary text-sm"
+										href={`/api/attachments/${attachment.id}`}
+										key={attachment.id ?? attachment.key ?? index}
+										rel="noopener noreferrer"
+										target="_blank"
+									>
+										Beleg {index + 1}
+										<ExternalLinkIcon className="size-3.5" />
+									</Link>
+								))}
+							</div>
+						</div>
+					) : null}
 				</CardContent>
 			</Card>
 

--- a/src/app/api/attachments/[id]/route.ts
+++ b/src/app/api/attachments/[id]/route.ts
@@ -1,0 +1,76 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { auth } from "@/server/better-auth";
+import { db } from "@/server/db";
+import { getFileExtension, getFileFromStorage } from "@/server/storage";
+
+const MIME_TYPES: Record<string, string> = {
+	jpg: "image/jpeg",
+	jpeg: "image/jpeg",
+	png: "image/png",
+	gif: "image/gif",
+	webp: "image/webp",
+	pdf: "application/pdf",
+};
+
+function getFilenameFromKey(key: string): string {
+	return key.split("/").at(-1) ?? "attachment";
+}
+
+export async function GET(
+	request: NextRequest,
+	{ params }: { params: Promise<{ id: string }> },
+) {
+	const session = await auth.api.getSession({
+		headers: request.headers,
+	});
+
+	if (!session?.user) {
+		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+	}
+
+	const { id } = await params;
+	const attachment = await db.attachment.findUnique({
+		where: { id },
+		select: {
+			key: true,
+			expense: {
+				select: {
+					report: {
+						select: {
+							ownerId: true,
+						},
+					},
+				},
+			},
+		},
+	});
+
+	if (!attachment) {
+		return NextResponse.json({ error: "Attachment not found" }, { status: 404 });
+	}
+
+	const isAdmin = session.user.role === "admin";
+	const isOwner = attachment.expense.report.ownerId === session.user.id;
+
+	if (!isAdmin && !isOwner) {
+		return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+	}
+
+	const file = await getFileFromStorage(attachment.key);
+
+	if (!file) {
+		return NextResponse.json({ error: "Attachment not found" }, { status: 404 });
+	}
+
+	const extension = getFileExtension(attachment.key);
+	const filename = getFilenameFromKey(attachment.key);
+	const contentType = MIME_TYPES[extension] ?? "application/octet-stream";
+
+	return new NextResponse(new Uint8Array(file), {
+		headers: {
+			"Content-Type": contentType,
+			"Content-Disposition": `inline; filename="${filename}"`,
+			"Cache-Control": "private, max-age=300",
+		},
+	});
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable direct viewing of receipt attachments from report expenses. Adds a secure `/api/attachments/[id]` endpoint and links receipts in the expense card to open inline in a new tab.

- **New Features**
  - Show “Belege” links for `RECEIPT` expenses; each link opens `/api/attachments/:id` in a new tab.
  - New API serves attachments with correct MIME type and `inline` disposition, enforces auth (admin or report owner), and sets a 5‑minute private cache.

- **Migration**
  - `expense.attachments` now requires `Attachment[]` (with `id` and `key`). Ensure the API returns full attachment objects.

<sup>Written for commit 90c81307c91d3a7ff0bb891bb469979b84fde84d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

