### PR TITLE
feat(web): remove logos from email

### DIFF
--- a/src/components/emails/expense-report-creator-notification.tsx
+++ b/src/components/emails/expense-report-creator-notification.tsx
@@ -52,16 +52,6 @@ export default function ExpenseReportCreatorNotification({
 			<Preview>{previewText}</Preview>
 			<Body style={main}>
 				<Container style={container}>
-					<Section style={logoSection}>
-						<Img
-							alt="move e.V. logo"
-							height={38}
-							src="cid:move-logo"
-							style={logo}
-							width={90}
-						/>
-					</Section>
-
 					<Section style={badgeSection}>
 						<Text style={badge}>
 							Spesenantrag <strong>{isCreated ? "erstellt" : "geändert"}</strong>

--- a/src/components/emails/expense-report-reviewer-notification.tsx
+++ b/src/components/emails/expense-report-reviewer-notification.tsx
@@ -55,16 +55,6 @@ export default function ExpenseReportReviewerNotification({
 			<Preview>{previewText}</Preview>
 			<Body style={main}>
 				<Container style={container}>
-					<Section style={logoSection}>
-						<Img
-							alt="move e.V. logo"
-							height={38}
-							src="cid:move-logo"
-							style={logo}
-							width={90}
-						/>
-					</Section>
-
 					<Section style={badgeSection}>
 						<Text style={badge}>
 							Spesenantrag <strong>{isCreated ? "erstellt" : "geändert"}</strong>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the logo section from the creator and reviewer expense report email templates. This simplifies the layout and avoids CID image issues in some email clients.

<sup>Written for commit 1c8bb3d522eb284a03f84fe934f7b02b75039504. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

