### PR TITLE
fix: force light mode regardless of system preferences

### DIFF
--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -13,9 +13,9 @@ export function Providers({
 		<NuqsAdapter>
 			<NextThemesProvider
 				attribute="class"
-				defaultTheme="system"
+				defaultTheme="light"
 				disableTransitionOnChange
-				enableSystem
+				forcedTheme="light"
 				{...props}
 			>
 				{children}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Force light mode across the app by updating the `next-themes` provider to set defaultTheme="light" and forcedTheme="light". This disables system-based theming and ensures a consistent light UI.

<sup>Written for commit d20e9ae3c1acc362c98ae01f9e2b993ba71b9150. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

