### PR TITLE
fix: update report PDF summary metadata

### DIFF
--- a/src/server/api/routers/report.tsx
+++ b/src/server/api/routers/report.tsx
@@ -16,7 +16,10 @@ import {
 	orgAdminProcedure,
 	orgProcedure,
 } from "@/server/api/trpc";
-import { generatePdfSummary } from "@/server/pdf/summary";
+import {
+	buildReportPdfFilename,
+	generatePdfSummary,
+} from "@/server/pdf/summary";
 
 export const reportRouter = createTRPCRouter({
 	// Get all reports for the current user
@@ -695,6 +698,12 @@ export const reportRouter = createTRPCRouter({
 						},
 					},
 					owner: true,
+					costUnit: {
+						select: {
+							tag: true,
+							title: true,
+						},
+					},
 					bankingDetails: true,
 				},
 			});
@@ -720,7 +729,7 @@ export const reportRouter = createTRPCRouter({
 
 			return {
 				pdf: base64Pdf,
-				filename: `${report.title.replace(/[^a-z0-9]/gi, "_")}_Zusammenfassung.pdf`,
+				filename: buildReportPdfFilename(report),
 			};
 		}),
 });

--- a/src/server/pdf/summary.ts
+++ b/src/server/pdf/summary.ts
@@ -20,6 +20,10 @@ interface SummaryProps {
 	report: Report & {
 		expenses: (Expense & { attachments: Attachment[] })[];
 		owner: User;
+		costUnit: {
+			tag: string;
+			title: string;
+		};
 		bankingDetails: {
 			iban: string;
 			fullName: string;
@@ -39,6 +43,30 @@ const COLUMN_WIDTHS = {
 	DETAILS: "*",
 	AMOUNT: 80,
 } as const;
+
+function formatEuroAmount(amount: number): string {
+	return `${amount.toFixed(2)}€`;
+}
+
+function toSnakeCaseFilenameSegment(value: string): string {
+	const normalizedValue = value
+		.normalize("NFKD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.toLowerCase();
+	const snakeCaseValue = normalizedValue
+		.replace(/[^a-z0-9]+/g, "_")
+		.replace(/^_+|_+$/g, "")
+		.replace(/_+/g, "_");
+
+	return snakeCaseValue || "report";
+}
+
+export function buildReportPdfFilename(
+	report: Pick<Report, "tag" | "title">,
+): string {
+	const escapedTitle = toSnakeCaseFilenameSegment(report.title);
+	return `Spesen_${report.tag}_${escapedTitle}.pdf`;
+}
 
 function formatExpenseMeta(expense: Expense): string {
 	if (expense.type === "TRAVEL") {
@@ -245,6 +273,9 @@ export async function generatePdfSummary({
 			align: "left",
 		},
 	);
+	doc.text(`Kostenstelle: ${report.costUnit.tag} | ${report.costUnit.title}`, {
+		align: "left",
+	});
 	doc.fillColor("black");
 	doc.moveDown(1);
 
@@ -331,7 +362,7 @@ export async function generatePdfSummary({
 				descriptionStr && metaStr
 					? `${descriptionStr} (${metaStr})`
 					: descriptionStr || metaStr || "-";
-			const amountStr = `${Number(expense.amount).toFixed(2)} €`;
+			const amountStr = formatEuroAmount(Number(expense.amount));
 
 			expensesTable.row([
 				typeStr,
@@ -344,7 +375,7 @@ export async function generatePdfSummary({
 
 		doc.font("Helvetica-Bold");
 		doc.fontSize(9);
-		expensesTable.row(["Gesamt", "", "", "", `${totalAmount.toFixed(2)} €`]);
+		expensesTable.row(["Gesamt", "", "", "", formatEuroAmount(totalAmount)]);
 	}
 
 	doc.moveDown(2);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the report PDF summary to include the cost unit and unify filename and currency formatting. Filenames now use “Spesen_<tag>_<title>.pdf”, and amounts use a consistent “€” format.

- **Bug Fixes**
  - Show cost unit (tag and title) in the PDF header.
  - Standardize euro amount formatting across rows and totals.
  - Generate filenames via a helper and return it from the API.
  - Fetch `costUnit` in the report query for PDF data.

<sup>Written for commit 5559e03b98b8c288a7b4bbeffedb82b87ae76212. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

