### PR TITLE
fix: make settings accessible on mobile

### DIFF
--- a/src/modules/settings/components/settings-layout.tsx
+++ b/src/modules/settings/components/settings-layout.tsx
@@ -4,9 +4,9 @@ import { SettingsSidebar } from "./settings-sidebar";
 function SettingsLayout({ children }: React.PropsWithChildren) {
 	return (
 		<main className="min-h-svh bg-zinc-50 py-20">
-			<div className="mx-auto flex w-full max-w-6xl gap-8 px-8">
-				<SettingsSidebar className="w-full max-w-64 shrink-0" />
-				<div className="grow">{children}</div>
+			<div className="mx-auto grid w-full max-w-6xl gap-12 px-8 lg:grid-cols-4 lg:gap-8">
+				<SettingsSidebar />
+				<div className="px-2.5 lg:col-span-3 lg:px-0">{children}</div>
 			</div>
 		</main>
 	);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the Settings layout responsive so it works on mobile. Replaced the fixed flex two-column layout with a grid that stacks the sidebar and adds mobile padding; on large screens it switches to 4 columns with the content spanning 3.

<sup>Written for commit f5fcf0fdb5a0ca25db2e3e250171e4620d7afbc4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

