### PR TITLE
feat: implement user dashboard

### DIFF
--- a/src/app/(app)/dashboard/layout.tsx
+++ b/src/app/(app)/dashboard/layout.tsx
@@ -1,0 +1,5 @@
+import { DashboardLayout } from "@/modules/dashboard";
+
+export default async function ServerLayout(props: LayoutProps<"/dashboard">) {
+	return <DashboardLayout>{props.children}</DashboardLayout>;
+}

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -1,0 +1,5 @@
+import { DashboardContent } from "@/modules/dashboard";
+
+export default async function ServerPage() {
+	return <DashboardContent />;
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils";
+
+function Navbar({ className, ...props }: React.ComponentProps<"nav">) {
+	return (
+		<nav
+			className={cn("h-12 w-full border-b [&>div]:h-12", className)}
+			data-slot="navbar"
+			{...props}
+		/>
+	);
+}
+
+export { Navbar };

--- a/src/components/page-title.tsx
+++ b/src/components/page-title.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils";
 export function PageTitle({ className, ...props }: React.ComponentProps<"h1">) {
 	return (
 		<h1
-			className={cn("font-semibold text-2xl text-foreground", className)}
+			className={cn("font-semibold text-foreground text-lg", className)}
 			data-slot="page-title"
 			{...props}
 		/>

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -13,4 +13,7 @@ export const ROUTES = {
 	SETTINGS_ADMIN_ORG_DETAILS: (id: string) => `/settings/admin/orgs/${id}`,
 
 	ADMIN_REVIEW_REPORT: (reportId: string) => `/admin/review/${reportId}`,
+
+	USER_REPORTS_LIST: () => "#",
+	USER_REPORT_DETAILS: (reportId: string) => `/reports/${reportId}`,
 } as const;

--- a/src/modules/dashboard/components/dashboard-content.tsx
+++ b/src/modules/dashboard/components/dashboard-content.tsx
@@ -1,0 +1,42 @@
+import { PageTitle } from "@/components/page-title";
+import { cn } from "@/lib/utils";
+import { DashboardReportList } from "./dashboard-report-list";
+import { DashboardStats } from "./dashboard-stats";
+
+function DashboardContent({
+	className,
+	...props
+}: React.ComponentProps<"main">) {
+	return (
+		<main
+			className={cn("py-12", className)}
+			data-slot="dashboard-content"
+			{...props}
+		>
+			<DashboarHeader />
+			<section className="container mt-8">
+				<DashboardStats />
+			</section>
+			<section className="container mt-12">
+				<DashboardReportList />
+			</section>
+		</main>
+	);
+}
+
+function DashboarHeader({
+	className,
+	...props
+}: React.ComponentProps<"section">) {
+	return (
+		<section
+			className={cn("container", className)}
+			data-slot="dashboard-header"
+			{...props}
+		>
+			<PageTitle>Dashboard</PageTitle>
+		</section>
+	);
+}
+
+export { DashboardContent };

--- a/src/modules/dashboard/components/dashboard-layout.tsx
+++ b/src/modules/dashboard/components/dashboard-layout.tsx
@@ -1,0 +1,17 @@
+import { cn } from "@/lib/utils";
+import { DashboardNavbar } from "./dashboard-navbar";
+
+function DashboardLayout({
+	className,
+	children,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div className={cn("", className)} data-slot="component" {...props}>
+			<DashboardNavbar />
+			{children}
+		</div>
+	);
+}
+
+export { DashboardLayout };

--- a/src/modules/dashboard/components/dashboard-navbar.tsx
+++ b/src/modules/dashboard/components/dashboard-navbar.tsx
@@ -1,0 +1,18 @@
+import { Navbar } from "@/components/navbar";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { cn } from "@/lib/utils";
+
+function DashboardNavbar({
+	className,
+	...props
+}: React.ComponentProps<typeof Navbar>) {
+	return (
+		<Navbar className={cn("", className)} data-slot="dashboard-navbar" {...props}>
+			<div className="container flex items-center justify-start">
+				<SidebarTrigger />
+			</div>
+		</Navbar>
+	);
+}
+
+export { DashboardNavbar };

--- a/src/modules/dashboard/components/dashboard-report-list.tsx
+++ b/src/modules/dashboard/components/dashboard-report-list.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { format } from "date-fns";
+import { ArrowRightIcon } from "lucide-react";
+import Link from "next/link";
+import { buttonVariants } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import type { Report as ReportPrimitive } from "@/generated/prisma/client";
+import { StatusIcons } from "@/lib/icons";
+import { ROUTES } from "@/lib/routes";
+import { cn, translateReportStatus } from "@/lib/utils";
+import { api } from "@/trpc/react";
+
+type Report = ReportPrimitive & {
+	sum: number;
+};
+
+function DashboardReportList({
+	className,
+	...props
+}: React.ComponentProps<"section">) {
+	const {
+		data: reports,
+		isPending,
+		error,
+	} = api.report.listOwn.useQuery({ page: 1, pageSize: 10 });
+
+	if (isPending) {
+		return (
+			<section
+				className={cn("space-y-4", className)}
+				data-slot="dashboard-report-list"
+				{...props}
+			>
+				<ReportListHeader />
+				<Skeleton className="min-h-24 w-full" />
+			</section>
+		);
+	}
+
+	if (!reports || error) {
+		return (
+			<section
+				className={cn("space-y-4", className)}
+				data-slot="dashboard-report-list"
+				{...props}
+			>
+				<ReportListHeader />
+				<div className="flex min-h-24 flex-col items-center justify-center gap-1 rounded-md border border-dashed px-6 py-10">
+					<p className="text-center font-medium text-destructive text-sm">
+						Fehler beim Laden der Anhänge
+					</p>
+					<p className="text-center text-xs">
+						{error?.message ?? "Ein unbekannter Fehler ist aufgetreten"}
+					</p>
+				</div>
+			</section>
+		);
+	}
+
+	if (reports.length === 0) {
+		return (
+			<section
+				className={cn("space-y-4", className)}
+				data-slot="dashboard-report-list"
+				{...props}
+			>
+				<ReportListHeader />
+				<div className="flex min-h-24 flex-col items-center justify-center gap-1 rounded-md border border-dashed px-6 py-10">
+					<p className="text-center font-medium text-sm">Keine Anträge gefunden</p>
+					<p className="text-center text-muted-foreground text-xs">
+						Es sieht so aus als hättest du noch keinen Antrag eingereicht.
+					</p>
+				</div>
+			</section>
+		);
+	}
+
+	return (
+		<section
+			className={cn("space-y-4", className)}
+			data-slot="dashboard-report-list"
+			{...props}
+		>
+			<ReportListHeader />
+			<ReportList reports={reports} />
+		</section>
+	);
+}
+
+function ReportListHeader({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn("flex items-center justify-between gap-2", className)}
+			data-slot="component"
+			{...props}
+		>
+			<p className="font-medium">Deine Anträge</p>
+			<Link
+				className={cn(
+					buttonVariants({ variant: "ghost", size: "sm" }),
+					"translate-x-2.5 text-blue-500",
+				)}
+				href={ROUTES.USER_REPORTS_LIST()}
+			>
+				Alle Anträge <ArrowRightIcon />
+			</Link>
+		</div>
+	);
+}
+
+function ReportList({
+	className,
+	reports,
+	...props
+}: React.ComponentProps<"div"> & { reports: Report[] }) {
+	return (
+		<div
+			className={cn(
+				"w-full overflow-hidden rounded-lg bg-white shadow-sm ring-1 ring-zinc-700/15",
+				className,
+			)}
+			data-slot="report-list"
+			{...props}
+		>
+			<table className="w-full">
+				<thead>
+					<tr className="bg-zinc-100">
+						<th className="px-3 py-2 text-left font-medium text-muted-foreground text-xs">
+							Antrag
+						</th>
+						<th className="px-3 py-2 text-left font-medium text-muted-foreground text-xs">
+							Datum
+						</th>
+						<th className="px-3 py-2 text-left font-medium text-muted-foreground text-xs">
+							Ausgaben
+						</th>
+						<th className="px-3 py-2 text-left font-medium text-muted-foreground text-xs">
+							Status
+						</th>
+					</tr>
+				</thead>
+				<tbody>
+					{reports.map((report) => {
+						const Icon = StatusIcons[report.status];
+
+						return (
+							<tr key={report.id}>
+								<td className="px-3 py-3">
+									<Link
+										className="block font-medium text-foreground text-sm"
+										href={ROUTES.USER_REPORT_DETAILS(report.id)}
+									>
+										{report.title}
+									</Link>
+								</td>
+								<td className="p-3 text-muted-foreground text-sm">
+									{format(report.createdAt, "dd.MM.yyyy")}
+								</td>
+								<td className="p-3 text-muted-foreground text-sm">{report.sum} €</td>
+								<td className="p-3">
+									<span
+										className={cn(
+											"flex items-center justify-start gap-1.5 font-medium text-sm",
+											report.status === "DRAFT" && "text-muted-foreground",
+											report.status === "PENDING_APPROVAL" && "text-yellow-500",
+											report.status === "NEEDS_REVISION" && "text-orange-500",
+											report.status === "ACCEPTED" && "text-green-600",
+											report.status === "REJECTED" && "text-red-600",
+										)}
+									>
+										<Icon className="size-3.5 shrink-0" />
+										<span className="block shrink-0">
+											{translateReportStatus(report.status)}
+										</span>
+									</span>
+								</td>
+							</tr>
+						);
+					})}
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+export { DashboardReportList };

--- a/src/modules/dashboard/components/dashboard-stats.tsx
+++ b/src/modules/dashboard/components/dashboard-stats.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { format } from "date-fns";
+import { de } from "date-fns/locale";
+import { ArrowDownIcon, ArrowUpIcon, CalendarIcon } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import { api } from "@/trpc/react";
+
+const EUR_FORMATTER = new Intl.NumberFormat("de-DE", {
+	currency: "EUR",
+	style: "currency",
+});
+
+type StatsMetric = {
+	amount: number;
+	changePercent: number | null;
+	comparisonPeriodStart: Date;
+	periodStart: Date;
+};
+
+type StatsCardProps = React.ComponentProps<"div"> & {
+	comparisonFormat: string;
+	label: string;
+	metric: StatsMetric;
+	periodFormat: string;
+};
+
+function formatChangePercent(changePercent: number | null): string {
+	if (changePercent === null) {
+		return "Keine Vergleichsdaten";
+	}
+
+	if (changePercent > 0) {
+		return `+${changePercent}%`;
+	}
+
+	return `${changePercent}%`;
+}
+
+function getChangeText(metric: StatsMetric, comparisonFormat: string): string {
+	const formattedChange = formatChangePercent(metric.changePercent);
+
+	if (metric.changePercent === null) {
+		return formattedChange;
+	}
+
+	return `${formattedChange} zu ${format(metric.comparisonPeriodStart, comparisonFormat, { locale: de })}`;
+}
+
+function getChangeColor(changePercent: number | null): string {
+	if (changePercent === null || changePercent === 0) {
+		return "text-muted-foreground";
+	}
+
+	return changePercent > 0 ? "text-green-500" : "text-red-500";
+}
+
+function StatsCard({
+	className,
+	comparisonFormat,
+	label,
+	metric,
+	periodFormat,
+	...props
+}: StatsCardProps) {
+	const isPositiveChange =
+		metric.changePercent !== null && metric.changePercent > 0;
+	const TrendIcon = isPositiveChange ? ArrowUpIcon : ArrowDownIcon;
+
+	return (
+		<div className={cn("bg-white p-5", className)} {...props}>
+			<div className="flex w-fit items-center justify-center gap-1.5">
+				<CalendarIcon className="size-3.5 text-zinc-500" />
+				<span className="block font-medium text-xs text-zinc-500">
+					{label} in {format(metric.periodStart, periodFormat, { locale: de })}
+				</span>
+			</div>
+			<p className="mt-6 font-medium text-foreground text-xl md:text-2xl">
+				{EUR_FORMATTER.format(metric.amount)}
+			</p>
+			<div
+				className={cn(
+					"mt-2 flex items-center justify-start gap-1.5 text-sm",
+					getChangeColor(metric.changePercent),
+				)}
+			>
+				{metric.changePercent !== null && <TrendIcon className="size-3.5" />}
+				<span className="block">{getChangeText(metric, comparisonFormat)}</span>
+			</div>
+		</div>
+	);
+}
+
+function DashboardStats({ className, ...props }: React.ComponentProps<"div">) {
+	const { data: stats, error, isPending } = api.dashboard.getStats.useQuery();
+
+	if (isPending) {
+		return <Skeleton className={cn("min-h-32 w-full", className)} {...props} />;
+	}
+
+	if (!stats || error) {
+		return (
+			<div
+				className={cn(
+					"flex min-h-32 flex-col items-center justify-center gap-1 rounded-lg border border-dashed bg-white px-6 py-10",
+					className,
+				)}
+				data-slot="dashboard-stats"
+				{...props}
+			>
+				<p className="text-center font-medium text-destructive text-sm">
+					Fehler beim Laden der Statistik
+				</p>
+				<p className="text-center text-xs">
+					{error?.message ?? "Ein unbekannter Fehler ist aufgetreten"}
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div
+			className={cn(
+				"grid gap-px rounded-lg bg-linear-to-b from-zinc-700/15 to-zinc-700/25 shadow-sm ring-1 ring-zinc-700/15 md:grid-cols-2",
+				className,
+			)}
+			data-slot="dashboard-stats"
+			{...props}
+		>
+			<StatsCard
+				className="rounded-t-lg md:rounded-l-lg md:rounded-tr-none"
+				comparisonFormat="MMMM"
+				label="Ausgaben"
+				metric={stats.monthlyExpenses}
+				periodFormat="MMMM"
+			/>
+			<StatsCard
+				className="rounded-b-lg md:rounded-r-lg md:rounded-l-none"
+				comparisonFormat="yyyy"
+				label="Erstattet"
+				metric={stats.yearlyReimbursed}
+				periodFormat="yyyy"
+			/>
+		</div>
+	);
+}
+
+export { DashboardStats };

--- a/src/modules/dashboard/components/index.ts
+++ b/src/modules/dashboard/components/index.ts
@@ -1,0 +1,2 @@
+export { DashboardContent } from "./dashboard-content";
+export { DashboardLayout } from "./dashboard-layout";

--- a/src/modules/dashboard/index.ts
+++ b/src/modules/dashboard/index.ts
@@ -1,0 +1,1 @@
+export { DashboardContent, DashboardLayout } from "./components";

--- a/src/modules/review/components/review-navbar.tsx
+++ b/src/modules/review/components/review-navbar.tsx
@@ -13,6 +13,7 @@ import {
 import Link from "next/link";
 import React from "react";
 import { toast } from "sonner";
+import { Navbar } from "@/components/navbar";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import {
@@ -23,6 +24,7 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Kbd } from "@/components/ui/kbd";
+import { SidebarTrigger } from "@/components/ui/sidebar";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
 	Tooltip,
@@ -56,8 +58,9 @@ function ReviewNavbar({
 
 	if (isPending) {
 		return (
-			<nav className={cn("w-full border-b", className)} {...props}>
-				<div className="mx-auto flex h-12 w-full max-w-7xl items-center justify-start gap-4 px-8 py-4">
+			<Navbar className={cn("", className)} {...props}>
+				<div className="container flex items-center justify-start gap-4 py-4">
+					<SidebarTrigger />
 					<div className="flex w-fit items-center justify-center gap-3">
 						<Link className="font-medium text-sm text-zinc-600" href={"#"}>
 							Reports
@@ -67,7 +70,7 @@ function ReviewNavbar({
 					</div>
 					<Navigation className="ml-auto" />
 				</div>
-			</nav>
+			</Navbar>
 		);
 	}
 
@@ -85,8 +88,9 @@ function ReviewNavbar({
 	};
 
 	return (
-		<nav className={cn("w-full border-b", className)} {...props}>
-			<div className="mx-auto flex h-12 w-full max-w-7xl items-center justify-start gap-4 px-8 py-4">
+		<Navbar className={cn("", className)} {...props}>
+			<div className="container flex items-center justify-start gap-4 py-4">
+				<SidebarTrigger />
 				<div className="flex w-fit items-center justify-center gap-3">
 					<Link className="font-medium text-sm text-zinc-600" href={"#"}>
 						Reports
@@ -99,7 +103,7 @@ function ReviewNavbar({
 				<MoreMenu report={navbarReport} />
 				<Navigation className="ml-auto" />
 			</div>
-		</nav>
+		</Navbar>
 	);
 }
 

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -1,5 +1,6 @@
 import { adminRouter } from "@/server/api/routers/admin";
 import { costUnitRouter } from "@/server/api/routers/cost-unit";
+import { dashboardRouter } from "@/server/api/routers/dashboard";
 import { expenseRouter } from "@/server/api/routers/expense";
 import { legalRouter } from "@/server/api/routers/legal";
 import { platformAdminRouter } from "@/server/api/routers/platform-admin";
@@ -17,6 +18,7 @@ import { preferencesRouter } from "./routers/preferences";
  * All routers added in /api/routers should be manually added here.
  */
 export const appRouter = createTRPCRouter({
+	dashboard: dashboardRouter,
 	report: reportRouter,
 	expense: expenseRouter,
 	legal: legalRouter,

--- a/src/server/api/routers/dashboard.ts
+++ b/src/server/api/routers/dashboard.ts
@@ -1,0 +1,191 @@
+import {
+	addMonths,
+	addYears,
+	startOfMonth,
+	startOfYear,
+	subMonths,
+	subYears,
+} from "date-fns";
+import type { Prisma } from "@/generated/prisma/client";
+import { ReportStatus } from "@/generated/prisma/enums";
+import { createTRPCRouter, orgProcedure } from "@/server/api/trpc";
+
+type PeriodRange = {
+	start: Date;
+	end: Date;
+};
+
+type PeriodComparison = {
+	current: PeriodRange;
+	previous: PeriodRange;
+};
+
+type AmountAggregateResult = {
+	_sum: {
+		amount: Prisma.Decimal | null;
+	};
+};
+
+type DashboardStatsMetric = {
+	amount: number;
+	changePercent: number | null;
+	comparisonPeriodStart: Date;
+	periodStart: Date;
+};
+
+function getMonthComparison(now: Date): PeriodComparison {
+	const currentStart = startOfMonth(now);
+	const previousStart = subMonths(currentStart, 1);
+
+	return {
+		current: {
+			start: currentStart,
+			end: addMonths(currentStart, 1),
+		},
+		previous: {
+			start: previousStart,
+			end: currentStart,
+		},
+	};
+}
+
+function getYearComparison(now: Date): PeriodComparison {
+	const currentStart = startOfYear(now);
+	const previousStart = subYears(currentStart, 1);
+
+	return {
+		current: {
+			start: currentStart,
+			end: addYears(currentStart, 1),
+		},
+		previous: {
+			start: previousStart,
+			end: currentStart,
+		},
+	};
+}
+
+function amountFromAggregate(result: AmountAggregateResult): number {
+	return result._sum.amount ? Number(result._sum.amount) : 0;
+}
+
+function calculateChangePercent(
+	currentAmount: number,
+	previousAmount: number,
+): number | null {
+	if (previousAmount === 0) {
+		return null;
+	}
+
+	return Math.round(((currentAmount - previousAmount) / previousAmount) * 100);
+}
+
+function buildMetric(
+	currentAggregate: AmountAggregateResult,
+	previousAggregate: AmountAggregateResult,
+	currentPeriodStart: Date,
+	previousPeriodStart: Date,
+): DashboardStatsMetric {
+	const currentAmount = amountFromAggregate(currentAggregate);
+	const previousAmount = amountFromAggregate(previousAggregate);
+
+	return {
+		amount: currentAmount,
+		changePercent: calculateChangePercent(currentAmount, previousAmount),
+		comparisonPeriodStart: previousPeriodStart,
+		periodStart: currentPeriodStart,
+	};
+}
+
+export const dashboardRouter = createTRPCRouter({
+	getStats: orgProcedure.query(async ({ ctx }) => {
+		const now = new Date();
+		const monthComparison = getMonthComparison(now);
+		const yearComparison = getYearComparison(now);
+		const ownerReportFilter = {
+			organizationId: ctx.organizationId,
+			ownerId: ctx.session.user.id,
+		};
+
+		const [
+			currentMonthExpenses,
+			previousMonthExpenses,
+			currentYearReimbursed,
+			previousYearReimbursed,
+		] = await ctx.db.$transaction([
+			ctx.db.expense.aggregate({
+				where: {
+					report: {
+						...ownerReportFilter,
+						createdAt: {
+							gte: monthComparison.current.start,
+							lt: monthComparison.current.end,
+						},
+					},
+				},
+				_sum: {
+					amount: true,
+				},
+			}),
+			ctx.db.expense.aggregate({
+				where: {
+					report: {
+						...ownerReportFilter,
+						createdAt: {
+							gte: monthComparison.previous.start,
+							lt: monthComparison.previous.end,
+						},
+					},
+				},
+				_sum: {
+					amount: true,
+				},
+			}),
+			ctx.db.expense.aggregate({
+				where: {
+					report: {
+						...ownerReportFilter,
+						createdAt: {
+							gte: yearComparison.current.start,
+							lt: yearComparison.current.end,
+						},
+						status: ReportStatus.ACCEPTED,
+					},
+				},
+				_sum: {
+					amount: true,
+				},
+			}),
+			ctx.db.expense.aggregate({
+				where: {
+					report: {
+						...ownerReportFilter,
+						createdAt: {
+							gte: yearComparison.previous.start,
+							lt: yearComparison.previous.end,
+						},
+						status: ReportStatus.ACCEPTED,
+					},
+				},
+				_sum: {
+					amount: true,
+				},
+			}),
+		]);
+
+		return {
+			monthlyExpenses: buildMetric(
+				currentMonthExpenses,
+				previousMonthExpenses,
+				monthComparison.current.start,
+				monthComparison.previous.start,
+			),
+			yearlyReimbursed: buildMetric(
+				currentYearReimbursed,
+				previousYearReimbursed,
+				yearComparison.current.start,
+				yearComparison.previous.start,
+			),
+		};
+	}),
+});

--- a/src/server/api/routers/report.tsx
+++ b/src/server/api/routers/report.tsx
@@ -15,6 +15,7 @@ import {
 	createTRPCRouter,
 	orgAdminProcedure,
 	orgProcedure,
+	protectedProcedure,
 } from "@/server/api/trpc";
 import {
 	buildReportPdfFilename,
@@ -22,6 +23,39 @@ import {
 } from "@/server/pdf/summary";
 
 export const reportRouter = createTRPCRouter({
+	listOwn: protectedProcedure
+		.input(
+			z.object({
+				page: z.number().min(1),
+				pageSize: z.number(),
+			}),
+		)
+		.query(async ({ ctx, input }) => {
+			const userId = ctx.session.user.id;
+
+			const reports = await ctx.db.report.findMany({
+				where: {
+					ownerId: userId,
+				},
+				include: {
+					expenses: {
+						select: {
+							amount: true,
+						},
+					},
+				},
+				take: input.pageSize,
+				skip: (input.page - 1) * input.pageSize,
+			});
+			return reports.map((report) => ({
+				...report,
+				sum: report.expenses.reduce(
+					(total, expense) => total + Number(expense.amount),
+					0,
+				),
+			}));
+		}),
+
 	// Get all reports for the current user
 	getAll: orgProcedure.query(async ({ ctx }) => {
 		const reports = await ctx.db.report.findMany({
@@ -50,6 +84,10 @@ export const reportRouter = createTRPCRouter({
 				...expense,
 				amount: Number(expense.amount),
 			})),
+			sum: report.expenses.reduce(
+				(sum, expense) => sum + Number(expense.amount),
+				0,
+			),
 		}));
 	}),
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -10,6 +10,10 @@
 
 @custom-variant dark (&:is(.dark *));
 
+@utility container {
+	@apply mx-auto max-w-6xl w-full px-8;
+}
+
 @theme inline {
 	--font-sans: var(--font-sans);
 	--font-mono: var(--font-mono);
@@ -55,8 +59,8 @@
 }
 
 :root {
-	--background: oklch(1 0 0);
-	--foreground: oklch(0.141 0.005 285.823);
+	--background: oklch(0.99 0 0);
+	--foreground: oklch(0.27 0.01 286);
 	--card: oklch(1 0 0);
 	--card-foreground: oklch(0.141 0.005 285.823);
 	--popover: oklch(1 0 0);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Implements a new user dashboard with stats and a recent reports table, plus supporting API endpoints and a shared navbar. This improves navigation and gives users a quick view of spending and reimbursements.

- **New Features**
  - New `/dashboard` page using `DashboardLayout`, `DashboardNavbar`, and `DashboardContent`.
  - Stats cards for monthly expenses and yearly reimbursed with trend vs previous period; backend `dashboard.getStats` added and registered.
  - “My reports” table (10 items) with totals, statuses, and loading/error states; consumes `report.listOwn`; links via `ROUTES.USER_REPORT_DETAILS` and placeholder `ROUTES.USER_REPORTS_LIST`.
  - Shared `Navbar` component for consistent top bars.

- **Refactors**
  - Review navbar now uses the shared `Navbar` and includes `SidebarTrigger`.
  - Added `container` utility and minor color token tweaks; reduced `PageTitle` size for hierarchy.

<sup>Written for commit ad4cd5935b29da1a78abcba79585b85969e2a69b. Summary will update on new commits. <a href="https://cubic.dev/pr/zemio-co/zemio/pull/122?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

