### PR TITLE
chore: add Railway deployment configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**/node_modules
+**/.next
+**/.turbo
+**/dist
+**/*.log
+.git
+.env*
+docker-compose.yml

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+
+FROM oven/bun:1.3.14-alpine AS runner
+WORKDIR /app
+
+# Copy manifests before source so Docker can cache the install layer.
+# packages/db/prisma is required by the @zemio/db postinstall script
+# (prisma generate) that runs during bun install.
+COPY package.json bun.lock ./
+COPY apps/api/package.json ./apps/api/
+COPY packages/db/package.json ./packages/db/
+COPY packages/db/prisma/ ./packages/db/prisma/
+COPY packages/encryption/package.json ./packages/encryption/
+COPY packages/typescript-config/package.json ./packages/typescript-config/
+
+RUN bun install --frozen-lockfile
+
+COPY apps/api/ ./apps/api/
+COPY packages/ ./packages/
+
+# Regenerate the Prisma client now that full source is present.
+RUN bun --cwd packages/db run generate
+
+ENV NODE_ENV=production
+
+EXPOSE 3001
+
+CMD ["bun", "apps/api/src/index.ts"]

--- a/apps/api/railway.toml
+++ b/apps/api/railway.toml
@@ -1,0 +1,10 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "apps/api/Dockerfile"
+watchPatterns = ["apps/api/**", "packages/**"]
+
+[deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 60
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,70 @@
+# syntax=docker/dockerfile:1
+
+# ── Base: Bun + Node.js for building ─────────────────────────────────────────
+FROM oven/bun:1.3.14-alpine AS base
+RUN apk add --no-cache nodejs
+
+# ── Deps: install all workspace dependencies ──────────────────────────────────
+FROM base AS deps
+WORKDIR /app
+
+# Copy manifests before source so Docker can cache the install layer.
+# packages/db/prisma is required because the @zemio/db postinstall
+# script runs `prisma generate` during bun install.
+COPY package.json bun.lock ./
+COPY apps/web/package.json ./apps/web/
+COPY packages/db/package.json ./packages/db/
+COPY packages/db/prisma/ ./packages/db/prisma/
+COPY packages/encryption/package.json ./packages/encryption/
+COPY packages/typescript-config/package.json ./packages/typescript-config/
+
+RUN bun install --frozen-lockfile
+
+# ── Builder: compile Next.js app ──────────────────────────────────────────────
+FROM base AS builder
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# Regenerate the Prisma client now that full source is present.
+# The postinstall in the deps stage ran without packages/db/src, so we
+# must re-run generate here to produce a complete client.
+RUN bun --cwd packages/db run generate
+
+ENV SKIP_ENV_VALIDATION=1
+ENV NODE_ENV=production
+
+RUN bun run turbo build --filter=@zemio/web
+
+# Next.js standalone does not include static assets; copy them into the
+# standalone directory so the server can serve them correctly.
+RUN cp -r apps/web/.next/static apps/web/.next/standalone/.next/static && \
+    cp -r apps/web/public apps/web/.next/standalone/public
+
+# ── Runner: slim Node.js image ────────────────────────────────────────────────
+# node:22-slim (Debian) is required because the Prisma migration CLI needs
+# glibc. Alpine (musl) is incompatible with Prisma's default migration engine
+# binary without additional binaryTargets configuration in schema.prisma.
+FROM node:22-slim AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV HOSTNAME=0.0.0.0
+
+RUN groupadd --system --gid 1001 nodejs && \
+    useradd --system --uid 1001 --gid nodejs nextjs
+
+# Install the Prisma CLI so the preDeployCommand can run migrations.
+# Version must stay in sync with the prisma devDependency in packages/db.
+RUN npm install -g prisma@7 --quiet
+
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
+# Schema is required by `prisma migrate deploy` at pre-deploy time.
+COPY --from=builder --chown=nextjs:nodejs /app/packages/db/prisma ./packages/db/prisma
+
+USER nextjs
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -3,13 +3,20 @@
  * for Docker builds.
  */
 
+import path from "node:path";
 import { withBetterStack } from "@logtail/next";
 import { withSentryConfig } from "@sentry/nextjs";
 import { env } from "./src/env.js";
 
 /** @type {import("next").NextConfig} */
 const config = {
+	output: "standalone",
 	serverExternalPackages: ["pdfkit"],
+	experimental: {
+		// Required for standalone output to correctly trace workspace package files
+		// (packages/db, packages/encryption) in the monorepo.
+		outputFileTracingRoot: path.resolve(import.meta.dirname, "../.."),
+	},
 };
 
 const sourceMapUploadConfig =

--- a/apps/web/railway.toml
+++ b/apps/web/railway.toml
@@ -1,0 +1,11 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "apps/web/Dockerfile"
+watchPatterns = ["apps/web/**", "packages/**"]
+
+[deploy]
+preDeployCommand = ["prisma migrate deploy --schema=packages/db/prisma/schema.prisma"]
+healthcheckPath = "/api/health"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+	return Response.json({ status: "ok" });
+}


### PR DESCRIPTION
- Add Dockerfiles for apps/web (multi-stage, node:22-slim runner) and apps/api (single-stage Bun runtime)
- Add railway.toml for each service with Dockerfile builder, watch paths, healthcheck, and pre-deploy Prisma migration for web
- Enable Next.js standalone output with outputFileTracingRoot set to the monorepo root so workspace packages are correctly traced
- Add /api/health endpoint for Railway health checks
- Add .dockerignore to exclude node_modules, .next, .env* from build context

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Railway deployment configs for `apps/web` and `apps/api` using Dockerfiles, with health checks and a Next.js standalone build to support reliable, fast deploys.

- **New Features**
  - Dockerfiles: `apps/web` multi-stage (Bun+Node build, Node 22-slim runner), `apps/api` Bun runtime.
  - Railway configs: Dockerfile builder, watch patterns, health checks; web runs `prisma migrate deploy` pre-deploy.
  - Next.js: enable `output: "standalone"` and set `experimental.outputFileTracingRoot` to the monorepo root for proper tracing.
  - Health check: add `apps/web` `/api/health` route; configure healthcheck paths in each service.
  - Add `.dockerignore` to cut build context (e.g., `node_modules`, `.next`, `.env*`).

<sup>Written for commit dd50f3b1242b90e45717fc7c2b9792b3b17e1e93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zemio-co/zemio/pull/130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

