### PR TITLE
feat(web): imrove obersvability

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -4,7 +4,6 @@
  */
 
 import path from "node:path";
-import { withBetterStack } from "@logtail/next";
 import { withSentryConfig } from "@sentry/nextjs";
 import { env } from "./src/env.js";
 
@@ -12,11 +11,9 @@ import { env } from "./src/env.js";
 const config = {
 	output: "standalone",
 	serverExternalPackages: ["pdfkit"],
-	experimental: {
-		// Required for standalone output to correctly trace workspace package files
-		// (packages/db, packages/encryption) in the monorepo.
-		outputFileTracingRoot: path.resolve(import.meta.dirname, "../.."),
-	},
+	// Required for standalone output to correctly trace workspace package files
+	// (packages/db, packages/encryption) in the monorepo.
+	outputFileTracingRoot: path.resolve(import.meta.dirname, "../.."),
 };
 
 const sourceMapUploadConfig =
@@ -29,21 +26,19 @@ const sourceMapUploadConfig =
 			}
 		: {};
 
-export default withBetterStack(
-	withSentryConfig(config, {
-		// Only print logs for uploading source maps in CI
-		silent: !process.env.CI,
+export default withSentryConfig(config, {
+	// Only print logs for uploading source maps in CI
+	silent: !process.env.CI,
 
-		// Upload a larger set of source maps for prettier stack traces (increases build time)
-		widenClientFileUpload: true,
+	// Upload a larger set of source maps for prettier stack traces (increases build time)
+	widenClientFileUpload: true,
 
-		webpack: {
-			// Tree-shaking options for reducing bundle size
-			treeshake: {
-				// Automatically tree-shake Sentry logger statements to reduce bundle size
-				removeDebugLogging: true,
-			},
+	webpack: {
+		// Tree-shaking options for reducing bundle size
+		treeshake: {
+			// Automatically tree-shake Sentry logger statements to reduce bundle size
+			removeDebugLogging: true,
 		},
-		...sourceMapUploadConfig,
-	}),
-);
+	},
+	...sourceMapUploadConfig,
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,7 +22,7 @@
 		"@aws-sdk/s3-request-presigner": "^3.1029.0",
 		"@base-ui/react": "^1.1.0",
 		"@better-auth/prisma-adapter": "^1.6.14",
-		"@logtail/next": "^0.3.1",
+		"@zemio/logger": "workspace:*",
 		"@prisma/adapter-neon": "^7.2.0",
 		"@prisma/client": "^7.2.0",
 		"@react-email/components": "1.0.4",

--- a/apps/web/src/lib/logger.ts
+++ b/apps/web/src/lib/logger.ts
@@ -1,12 +1,10 @@
 import "server-only";
 
-import { Logger } from "@logtail/next";
+import { createLogger } from "@zemio/logger";
 
-/**
- * Server-side structured logger backed by Better Stack Logs.
- *
- * Use this in any server-only code (tRPC routers, storage clients, PDF generation, etc.).
- * Always call `void logger.flush()` after logging in fire-and-forget contexts, or
- * `await logger.flush()` before re-throwing errors to guarantee delivery.
- */
-export const logger = new Logger();
+import { env } from "@/env";
+
+export const logger = createLogger({
+	token: env.NEXT_PUBLIC_BETTER_STACK_SOURCE_TOKEN,
+	service: "web",
+});

--- a/apps/web/src/server/api/routers/attachment.ts
+++ b/apps/web/src/server/api/routers/attachment.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
+import { logger } from "@/lib/logger";
 import {
 	createTRPCRouter,
 	orgAdminProcedure,
@@ -217,6 +218,12 @@ export const attachmentRouter = createTRPCRouter({
 					return { url, key };
 				}),
 			);
+
+			logger.info("attachment.upload_initiated", {
+				organizationId: ctx.organizationId,
+				actorId: ctx.session.user.id,
+				count: input.files.length,
+			});
 
 			return { presignedUrls };
 		}),

--- a/apps/web/src/server/api/routers/report.tsx
+++ b/apps/web/src/server/api/routers/report.tsx
@@ -525,6 +525,13 @@ export const reportRouter = createTRPCRouter({
 				});
 			}
 
+			logger.info("report.status_changed", {
+				reportId: input.id,
+				organizationId: ctx.organizationId,
+				actorId: ctx.session.user.id,
+				status: input.status,
+			});
+
 			if (
 				!input.notify ||
 				result.owner.preferences?.notifications === NotificationPreference.NONE
@@ -625,6 +632,13 @@ export const reportRouter = createTRPCRouter({
 				});
 			}
 
+			logger.info("report.submitted", {
+				reportId: input.id,
+				organizationId: ctx.organizationId,
+				actorId: ctx.session.user.id,
+				previousStatus: status,
+			});
+
 			// Update the status to pending approval
 			const res = await ctx.db.report.update({
 				where: { id: input.id },
@@ -692,6 +706,8 @@ export const reportRouter = createTRPCRouter({
 	exportToPdf: orgProcedure
 		.input(z.object({ id: z.string() }))
 		.mutation(async ({ ctx, input }) => {
+			const start = Date.now();
+
 			const response = await fetch(`${env.API_URL}/pdf/report/${input.id}`, {
 				method: "POST",
 				headers: {
@@ -720,6 +736,14 @@ export const reportRouter = createTRPCRouter({
 			}
 
 			const data = (await response.json()) as { url: string; filename: string };
+
+			logger.info("report.pdf_exported", {
+				reportId: input.id,
+				organizationId: ctx.organizationId,
+				actorId: ctx.session.user.id,
+				durationMs: Date.now() - start,
+			});
+
 			return { url: data.url, filename: data.filename };
 		}),
 });

--- a/apps/web/src/server/api/trpc.ts
+++ b/apps/web/src/server/api/trpc.ts
@@ -11,6 +11,8 @@ import { initTRPC, TRPCError } from "@trpc/server";
 import superjson from "superjson";
 import { ZodError } from "zod";
 
+import { logger } from "@/lib/logger";
+
 import { isOrganizationAdminRole } from "@/lib/organization";
 import { auth } from "@/server/better-auth";
 import { db } from "@/server/db";
@@ -128,6 +130,33 @@ const timingMiddleware = t.middleware(async ({ next, path }) => {
 	return result;
 });
 
+const loggingMiddleware = t.middleware(async ({ next, path, type, ctx }) => {
+	const start = Date.now();
+	const result = await next();
+	const durationMs = Date.now() - start;
+
+	const base = {
+		path,
+		type,
+		durationMs,
+		userId: ctx.session?.user?.id,
+		organizationId: ctx.activeMember?.organizationId,
+	};
+
+	if (result.ok) {
+		logger.info("trpc.request", { ...base, ok: true });
+	} else {
+		const { code, message } = result.error;
+		if (code === "INTERNAL_SERVER_ERROR") {
+			logger.error("trpc.request", { ...base, ok: false, code, message });
+		} else {
+			logger.info("trpc.request", { ...base, ok: false, code });
+		}
+	}
+
+	return result;
+});
+
 /**
  * Public (unauthenticated) procedure
  *
@@ -135,7 +164,9 @@ const timingMiddleware = t.middleware(async ({ next, path }) => {
  * guarantee that a user querying is authorized, but you can still access user session data if they
  * are logged in.
  */
-export const publicProcedure = t.procedure.use(timingMiddleware);
+export const publicProcedure = t.procedure
+	.use(timingMiddleware)
+	.use(loggingMiddleware);
 
 /**
  * Protected (authenticated) procedure

--- a/apps/web/src/server/better-auth/server.ts
+++ b/apps/web/src/server/better-auth/server.ts
@@ -3,6 +3,7 @@ import { betterAuth } from "better-auth/minimal";
 import { nextCookies } from "better-auth/next-js";
 import { admin as adminPlugin, organization } from "better-auth/plugins";
 import { env } from "@/env";
+import { logger } from "@/lib/logger";
 import { sendOrgInvitationEmail } from "@/server/better-auth/invitations";
 import { db } from "@/server/db";
 import { CURRENT_LEGAL_RELEASE } from "@/server/legal";
@@ -84,6 +85,10 @@ export const auth = betterAuth({
 		},
 		session: {
 			create: {
+				after: async (session) => {
+					logger.info("auth.session_created", { userId: session.userId });
+					void logger.flush();
+				},
 				before: async (session) => {
 					// Resolve the user's Microsoft Entra ID tenant from the stored
 					// idToken. The idToken is written to the account record by

--- a/bun.lock
+++ b/bun.lock
@@ -139,6 +139,19 @@
         "typescript": "^5.8.2",
       },
     },
+    "packages/logger": {
+      "name": "@zemio/logger",
+      "version": "0.0.0",
+      "dependencies": {
+        "@logtail/node": "^0.3.1",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.2.5",
+        "@types/node": "^22",
+        "@zemio/typescript-config": "workspace:*",
+        "typescript": "^5.8.2",
+      },
+    },
     "packages/typescript-config": {
       "name": "@zemio/typescript-config",
       "version": "0.0.0",
@@ -457,7 +470,17 @@
 
     "@kurkle/color": ["@kurkle/color@0.3.4", "", {}, "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="],
 
+    "@logtail/core": ["@logtail/core@0.3.0", "", { "dependencies": { "@logtail/tools": "^0.3.0", "@logtail/types": "^0.3.0" } }, "sha512-PK/n/r9DriHoOnnhHuBi5u303x5QU2wJCeOIRQr7e+bVBmvn8gF+LdBS/CSkZQkKQo8v0xrp4I1cdnBfH4LtQg=="],
+
     "@logtail/next": ["@logtail/next@0.3.1", "", { "dependencies": { "use-deep-compare": "^1.2.1", "whatwg-fetch": "^3.6.2" }, "peerDependencies": { "next": ">=15.0", "react": ">=18.0.0" } }, "sha512-RiIYLO51ax/TI67h6/TdCSh/mUmcSTtP5JbkcERcBK2/KIWylxLiPMK5SO5PA7NUfLJVaUIMYkqGHKIcVCKljw=="],
+
+    "@logtail/node": ["@logtail/node@0.3.3", "", { "dependencies": { "@logtail/core": "^0.3.0", "@logtail/types": "^0.3.0", "@msgpack/msgpack": "^2.5.1", "@types/stack-trace": "^0.0.29", "cross-fetch": "^3.0.4", "minimatch": "^3.0.4", "stack-trace": "^0.0.10" } }, "sha512-Wf19kXPhX4V9OHAYfFj0NtNffqHCgCP3TVg2A3/vCbBmFpmkvqsI0x2Tx1i4+MYzyzkVfam2MiSQAXzQ7uEFVQ=="],
+
+    "@logtail/tools": ["@logtail/tools@0.3.0", "", { "dependencies": { "@logtail/types": "^0.3.0" } }, "sha512-mjz6UmXB2aBNs+mztzeK/Zs7q6r/1UULB9TNvMdY969con0j2Op7rsFwpZ3sUw9cr3FFpdANOOY0E2SUzwC/pA=="],
+
+    "@logtail/types": ["@logtail/types@0.3.0", "", { "dependencies": { "js": "^0.1.0" } }, "sha512-Du6KiaFwChIKyDRTbjZ52ttagLbfAHif4Q/4Crdu/dadYBUaoXkICd8GivUCIT89APiYGSQ032Ku2d8gU3NnRg=="],
+
+    "@msgpack/msgpack": ["@msgpack/msgpack@2.8.0", "", {}, "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ=="],
 
     "@neondatabase/serverless": ["@neondatabase/serverless@1.1.0", "", {}, "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q=="],
 
@@ -843,6 +866,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/stack-trace": ["@types/stack-trace@0.0.29", "", {}, "sha512-TgfOX+mGY/NyNxJLIbDWrO9DjGoVSW9+aB8H2yy1fy32jsvxijhmyJI9fDFgvz3YP4lvJaq9DzdR/M1bOgVc9g=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
@@ -889,6 +914,8 @@
 
     "@zemio/encryption": ["@zemio/encryption@workspace:packages/encryption"],
 
+    "@zemio/logger": ["@zemio/logger@workspace:packages/logger"],
+
     "@zemio/typescript-config": ["@zemio/typescript-config@workspace:packages/typescript-config"],
 
     "@zemio/web": ["@zemio/web@workspace:apps/web"],
@@ -927,7 +954,7 @@
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
-    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
 
@@ -943,7 +970,7 @@
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
-    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+    "brace-expansion": ["brace-expansion@1.1.15", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg=="],
 
     "brotli": ["brotli@1.3.3", "", { "dependencies": { "base64-js": "^1.1.2" } }, "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg=="],
 
@@ -1013,6 +1040,8 @@
 
     "compare-func": ["compare-func@2.0.0", "", { "dependencies": { "array-ify": "^1.0.0", "dot-prop": "^5.1.0" } }, "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA=="],
 
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
     "conf": ["conf@15.1.0", "", { "dependencies": { "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "atomically": "^2.0.3", "debounce-fn": "^6.0.0", "dot-prop": "^10.0.0", "env-paths": "^3.0.0", "json-schema-typed": "^8.0.1", "semver": "^7.7.2", "uint8array-extras": "^1.5.0" } }, "sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og=="],
 
     "confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
@@ -1038,6 +1067,8 @@
     "cosmiconfig-typescript-loader": ["cosmiconfig-typescript-loader@6.3.0", "", { "dependencies": { "jiti": "2.6.1" }, "peerDependencies": { "@types/node": "*", "cosmiconfig": ">=9", "typescript": ">=5" } }, "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA=="],
 
     "cross-env": ["cross-env@10.1.0", "", { "dependencies": { "@epic-web/invariant": "^1.0.0", "cross-spawn": "^7.0.6" }, "bin": { "cross-env": "dist/bin/cross-env.js", "cross-env-shell": "dist/bin/cross-env-shell.js" } }, "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw=="],
+
+    "cross-fetch": ["cross-fetch@3.2.0", "", { "dependencies": { "node-fetch": "^2.7.0" } }, "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -1275,6 +1306,8 @@
 
     "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
 
+    "js": ["js@0.1.0", "", { "dependencies": { "commander": "~1.1.1" }, "bin": { "js": "./bin/js" } }, "sha512-ZBbGYOpact8QAH9RprFWL4RAESYwbDodxiuDjOnzwzzk9pBzKycoifGuUrHHcDixE/eLMKPHRaXenTgu1qXBqA=="],
+
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
@@ -1288,6 +1321,8 @@
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "keypress": ["keypress@0.1.0", "", {}, "sha512-x0yf9PL/nx9Nw9oLL8ZVErFAk85/lslwEP7Vz7s5SI1ODXZIgit3C5qyWjw4DxOuO/3Hb4866SQh28a1V1d+WA=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
@@ -1453,7 +1488,7 @@
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
-    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+    "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -1701,6 +1736,8 @@
 
     "sqlstring": ["sqlstring@2.3.3", "", {}, "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg=="],
 
+    "stack-trace": ["stack-trace@0.0.10", "", {}, "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg=="],
+
     "stacktrace-parser": ["stacktrace-parser@0.1.11", "", { "dependencies": { "type-fest": "^0.7.1" } }, "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg=="],
 
     "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
@@ -1921,7 +1958,11 @@
 
     "esrecurse/estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
+
+    "js/commander": ["commander@1.1.1", "", { "dependencies": { "keypress": "0.1.x" } }, "sha512-71Rod2AhcH3JhkBikVpNd0pA+fWsmAaVoti6OR38T76chA7vE3pSerS0Jor4wDw+tOueD2zLVvFOw5H0Rcj7rA=="],
 
     "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
@@ -1979,6 +2020,8 @@
 
     "@react-email/preview-server/next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
+    "@sentry/bundler-plugin-core/glob/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
     "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "c12/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
@@ -1988,6 +2031,8 @@
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "cosmiconfig/js-yaml/argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
 
@@ -2050,5 +2095,11 @@
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "@sentry/bundler-plugin-core/glob/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "@sentry/bundler-plugin-core/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,6 @@
         "@aws-sdk/s3-request-presigner": "^3.1029.0",
         "@base-ui/react": "^1.1.0",
         "@better-auth/prisma-adapter": "^1.6.14",
-        "@logtail/next": "^0.3.1",
         "@prisma/adapter-neon": "^7.2.0",
         "@prisma/client": "^7.2.0",
         "@react-email/components": "1.0.4",
@@ -67,6 +66,7 @@
         "@trpc/server": "^11.0.0",
         "@zemio/db": "workspace:*",
         "@zemio/encryption": "workspace:*",
+        "@zemio/logger": "workspace:*",
         "better-auth": "^1.6.14",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -471,8 +471,6 @@
     "@kurkle/color": ["@kurkle/color@0.3.4", "", {}, "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="],
 
     "@logtail/core": ["@logtail/core@0.3.0", "", { "dependencies": { "@logtail/tools": "^0.3.0", "@logtail/types": "^0.3.0" } }, "sha512-PK/n/r9DriHoOnnhHuBi5u303x5QU2wJCeOIRQr7e+bVBmvn8gF+LdBS/CSkZQkKQo8v0xrp4I1cdnBfH4LtQg=="],
-
-    "@logtail/next": ["@logtail/next@0.3.1", "", { "dependencies": { "use-deep-compare": "^1.2.1", "whatwg-fetch": "^3.6.2" }, "peerDependencies": { "next": ">=15.0", "react": ">=18.0.0" } }, "sha512-RiIYLO51ax/TI67h6/TdCSh/mUmcSTtP5JbkcERcBK2/KIWylxLiPMK5SO5PA7NUfLJVaUIMYkqGHKIcVCKljw=="],
 
     "@logtail/node": ["@logtail/node@0.3.3", "", { "dependencies": { "@logtail/core": "^0.3.0", "@logtail/types": "^0.3.0", "@msgpack/msgpack": "^2.5.1", "@types/stack-trace": "^0.0.29", "cross-fetch": "^3.0.4", "minimatch": "^3.0.4", "stack-trace": "^0.0.10" } }, "sha512-Wf19kXPhX4V9OHAYfFj0NtNffqHCgCP3TVg2A3/vCbBmFpmkvqsI0x2Tx1i4+MYzyzkVfam2MiSQAXzQ7uEFVQ=="],
 
@@ -1832,8 +1830,6 @@
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
-    "use-deep-compare": ["use-deep-compare@1.3.0", "", { "dependencies": { "dequal": "2.0.3" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-94iG+dEdEP/Sl3WWde+w9StIunlV8Dgj+vkt5wTwMoFQLaijiEZSXXy8KtcStpmEDtIptRJiNeD4ACTtVvnIKA=="],
-
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "valibot": ["valibot@1.2.0", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg=="],
@@ -1851,8 +1847,6 @@
     "webpack": ["webpack@5.107.2", "", { "dependencies": { "@types/estree": "^1.0.8", "@types/json-schema": "^7.0.15", "@webassemblyjs/ast": "^1.14.1", "@webassemblyjs/wasm-edit": "^1.14.1", "@webassemblyjs/wasm-parser": "^1.14.1", "acorn": "^8.16.0", "acorn-import-phases": "^1.0.3", "browserslist": "^4.28.1", "chrome-trace-event": "^1.0.2", "enhanced-resolve": "^5.22.0", "es-module-lexer": "^2.1.0", "eslint-scope": "5.1.1", "events": "^3.2.0", "glob-to-regexp": "^0.4.1", "graceful-fs": "^4.2.11", "loader-runner": "^4.3.2", "mime-db": "^1.54.0", "neo-async": "^2.6.2", "schema-utils": "^4.3.3", "tapable": "^2.3.0", "terser-webpack-plugin": "^5.5.0", "watchpack": "^2.5.1", "webpack-sources": "^3.5.0" }, "peerDependencies": { "webpack-cli": "*" }, "optionalPeers": ["webpack-cli"], "bin": { "webpack": "bin/webpack.js" } }, "sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ=="],
 
     "webpack-sources": ["webpack-sources@3.5.0", "", {}, "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ=="],
-
-    "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,25 @@
+{
+	"name": "@zemio/logger",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"exports": {
+		".": {
+			"types": "./src/index.ts",
+			"default": "./src/index.ts"
+		}
+	},
+	"scripts": {
+		"typecheck": "tsc --noEmit",
+		"check": "biome check ."
+	},
+	"dependencies": {
+		"@logtail/node": "^0.3.1"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.2.5",
+		"@types/node": "^22",
+		"@zemio/typescript-config": "workspace:*",
+		"typescript": "^5.8.2"
+	}
+}

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,0 +1,2 @@
+export { createLogger } from "./logger";
+export type { LogFields, Logger, LoggerOptions } from "./types";

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -1,0 +1,56 @@
+import { Logtail } from "@logtail/node";
+import type { LogFields, Logger, LoggerOptions } from "./types";
+
+export function createLogger({ token, service }: LoggerOptions): Logger {
+	if (!token) {
+		return createFallbackLogger(service);
+	}
+
+	const logtail = new Logtail(token);
+	const base = { service };
+
+	return {
+		debug: (message, fields) => {
+			void logtail.debug(message, { ...base, ...(fields ?? {}) });
+		},
+		info: (message, fields) => {
+			void logtail.info(message, { ...base, ...(fields ?? {}) });
+		},
+		warn: (message, fields) => {
+			void logtail.warn(message, { ...base, ...(fields ?? {}) });
+		},
+		error: (message, fields) => {
+			void logtail.error(message, { ...base, ...(fields ?? {}) });
+		},
+		flush: () => logtail.flush(),
+	};
+}
+
+function serializeEntry(
+	level: string,
+	service: string,
+	message: string,
+	fields?: LogFields,
+): string {
+	const entry: Record<string, unknown> = { level, service, message, ...fields };
+	return JSON.stringify(entry, (_key, value) => {
+		if (value instanceof Error) {
+			return { name: value.name, message: value.message };
+		}
+		return value as unknown;
+	});
+}
+
+function createFallbackLogger(service: string): Logger {
+	return {
+		debug: (msg, fields) =>
+			console.log(serializeEntry("debug", service, msg, fields)),
+		info: (msg, fields) =>
+			console.log(serializeEntry("info", service, msg, fields)),
+		warn: (msg, fields) =>
+			console.warn(serializeEntry("warn", service, msg, fields)),
+		error: (msg, fields) =>
+			console.error(serializeEntry("error", service, msg, fields)),
+		flush: () => Promise.resolve(),
+	};
+}

--- a/packages/logger/src/types.ts
+++ b/packages/logger/src/types.ts
@@ -1,0 +1,14 @@
+export type LogFields = Record<string, unknown>;
+
+export interface Logger {
+	debug(message: string, fields?: LogFields): void;
+	info(message: string, fields?: LogFields): void;
+	warn(message: string, fields?: LogFields): void;
+	error(message: string, fields?: LogFields): void;
+	flush(): Promise<void>;
+}
+
+export interface LoggerOptions {
+	token: string | undefined;
+	service: string;
+}

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "@zemio/typescript-config/base.json",
+	"compilerOptions": {
+		"rootDir": "src"
+	},
+	"include": ["src"],
+	"exclude": ["node_modules"]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves observability by centralizing structured logging and adding request and domain event logs across the web app. Introduces `@zemio/logger` and removes `@logtail/next`.

- New Features
  - Added `@zemio/logger` (wraps `@logtail/node`) with JSON console fallback when no token.
  - Web app now uses `createLogger({ token, service: "web" })`.
  - Added tRPC middleware that logs path, type, userId, organizationId, durationMs, and outcome; 500s are logged at error level.
  - Added domain logs: attachment.upload_initiated, report.status_changed, report.submitted, report.pdf_exported (with durationMs), and auth.session_created (flushes immediately).

- Refactors
  - Removed `withBetterStack` wrapper and the `@logtail/next` dependency.
  - Moved Next.js `outputFileTracingRoot` to the top-level config (no longer experimental).

<sup>Written for commit e00a80935248ae6b075d800be7877412e05afd49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zemio-co/zemio/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

