### PR TITLE
fix(docker): copy full installed tree into api builder stage

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -25,8 +25,11 @@ RUN bun install --frozen-lockfile
 FROM oven/bun:1.3.14-alpine AS runner
 WORKDIR /app
 
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=deps /app/apps/api/node_modules ./apps/api/node_modules
+# Copy the whole installed tree (root + every package's node_modules), then
+# overlay the full source. Per-package node_modules carry binaries that Bun does
+# not hoist (e.g. packages/db's prisma, packages/encryption's tsc), which the
+# build scripts need — copying them selectively is what broke the build.
+COPY --from=deps /app/ .
 COPY --from=pruner /app/out/full/ .
 
 # Build workspace dependencies to dist now that full source is present.


### PR DESCRIPTION
The api image copied only the root and apps/api node_modules, so the package-local binaries that Bun does not hoist — packages/db's prisma and packages/encryption's tsc — were absent when `turbo build` ran their build scripts, failing with exit 127 ("prisma: not found" / "tsc: not found").

Copy the whole deps tree (`COPY --from=deps /app/ .`) before overlaying the pruned source, mirroring the web image. This also brings bun.lock along, fixing the "Lockfile not found" turbo warning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `apps/api` Docker image build by copying the full installed tree from the deps stage (`COPY --from=deps /app/ .`), so package-local binaries and `bun.lock` are present. This unblocks `turbo build` and removes `prisma: not found` / `tsc: not found` errors.

<sup>Written for commit 68e02c1dfdd2fd4424a49a456072028ee19615b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zemio-co/zemio/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

