### PR TITLE
fix(web): use the pg driver adapter instead of the Neon adapter

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,7 +23,7 @@
 		"@base-ui/react": "^1.1.0",
 		"@better-auth/prisma-adapter": "^1.6.14",
 		"@zemio/logger": "workspace:*",
-		"@prisma/adapter-neon": "^7.2.0",
+		"@prisma/adapter-pg": "^7.2.0",
 		"@prisma/client": "^7.2.0",
 		"@react-email/components": "1.0.4",
 		"@react-email/render": "2.0.4",

--- a/apps/web/src/server/db.ts
+++ b/apps/web/src/server/db.ts
@@ -1,11 +1,11 @@
-import { PrismaNeon } from "@prisma/adapter-neon";
+import { PrismaPg } from "@prisma/adapter-pg";
 import { createDbClient, PrismaClient } from "@zemio/db";
 import { env } from "@/env";
 
 export const db = createDbClient(
 	() =>
 		new PrismaClient({
-			adapter: new PrismaNeon({ connectionString: env.DATABASE_URL }),
+			adapter: new PrismaPg({ connectionString: env.DATABASE_URL }),
 			log: env.NODE_ENV === "development" ? ["error"] : [],
 		}),
 );

--- a/bun.lock
+++ b/bun.lock
@@ -51,7 +51,7 @@
         "@aws-sdk/s3-request-presigner": "^3.1029.0",
         "@base-ui/react": "^1.1.0",
         "@better-auth/prisma-adapter": "^1.6.14",
-        "@prisma/adapter-neon": "^7.2.0",
+        "@prisma/adapter-pg": "^7.2.0",
         "@prisma/client": "^7.2.0",
         "@react-email/components": "1.0.4",
         "@react-email/render": "2.0.4",
@@ -480,8 +480,6 @@
 
     "@msgpack/msgpack": ["@msgpack/msgpack@2.8.0", "", {}, "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ=="],
 
-    "@neondatabase/serverless": ["@neondatabase/serverless@1.1.0", "", {}, "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q=="],
-
     "@next/env": ["@next/env@16.2.7", "", {}, "sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg=="],
 
     "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.2.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vm1EDI/pVaBNNiychmxk3fft+OhQPVD9cIM/tReLZIQ3TfQ4kqI9DwKk00dzuS1ulC7icbrzCFrmRRlk9PfNdw=="],
@@ -525,8 +523,6 @@
     "@pdf-lib/standard-fonts": ["@pdf-lib/standard-fonts@1.0.0", "", { "dependencies": { "pako": "^1.0.6" } }, "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA=="],
 
     "@pdf-lib/upng": ["@pdf-lib/upng@1.0.1", "", { "dependencies": { "pako": "^1.0.10" } }, "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ=="],
-
-    "@prisma/adapter-neon": ["@prisma/adapter-neon@7.8.0", "", { "dependencies": { "@neondatabase/serverless": ">0.6.0 <2", "@prisma/driver-adapter-utils": "7.8.0", "postgres-array": "3.0.4" } }, "sha512-9MoOjRuY53sQNyji87u1NivsK0tIacoUE3PqTxdG95b7ORn1pzwribH2z83j4Vh3eb9nQ/UC+MTfVW7jCFnXlA=="],
 
     "@prisma/adapter-pg": ["@prisma/adapter-pg@7.8.0", "", { "dependencies": { "@prisma/driver-adapter-utils": "7.8.0", "@types/pg": "^8.16.0", "pg": "^8.16.3", "postgres-array": "3.0.4" } }, "sha512-ygb3UkerK3v8MDpXVgCISdRNDozpxh6+JVJgiIGbSr5KBgz10LLf5ejUskPGoXlsIjxsOu6nuy1JVQr2EKGSlg=="],
 


### PR DESCRIPTION
The web Prisma client used @prisma/adapter-neon, which connects over a WebSocket to a Neon endpoint. The database is standard Railway Postgres (postgres.railway.internal), so the Neon adapter's connection fails immediately with an empty WebSocket ErrorEvent — surfacing as a 500 on every DB write (e.g. POST /api/auth/sign-in/social) while migrations and non-DB routes still work. Switch to @prisma/adapter-pg, matching apps/api, which already runs against the same database over TCP. The web app has no edge runtime, so the TCP-based pg adapter is appropriate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch web Prisma client to `@prisma/adapter-pg` to connect to Railway Postgres over TCP and stop 500 errors on DB writes. Aligns `apps/web` with `apps/api`.

- **Bug Fixes**
  - Removed Neon WebSocket adapter that couldn’t connect to `postgres.railway.internal`, which caused 500s on write routes (e.g., POST `/api/auth/sign-in/social`).
  - Uses the TCP `pg` adapter, appropriate for the Node runtime (no edge).

- **Dependencies**
  - Replaced `@prisma/adapter-neon` with `@prisma/adapter-pg`; updated `bun.lock`.

<sup>Written for commit 8320357a75e61495493c422a85e0c167810f4d86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zemio-co/zemio/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

