### PR TITLE
fix(web): make Sentry source-map upload logs visible during the image…

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -27,8 +27,12 @@ const sourceMapUploadConfig =
 		: {};
 
 export default withSentryConfig(config, {
-	// Only print logs for uploading source maps in CI
-	silent: !process.env.CI,
+	// Be verbose precisely when we are actually uploading source maps (i.e. when
+	// the Sentry credentials are present — the CI image build). Stay quiet locally
+	// where no auth token is configured. Using process.env.CI here does not work:
+	// CI is not propagated into the Docker build, so the upload would be silent in
+	// the one place we need its logs.
+	silent: !sourceMapUploadConfig.authToken,
 
 	// Upload a larger set of source maps for prettier stack traces (increases build time)
 	widenClientFileUpload: true,


### PR DESCRIPTION
… build

silent was gated on process.env.CI, but CI is not propagated into the Docker build, so the source-map upload ran silently inside CI — hiding failures (e.g. a 422 "Unknown project" when SENTRY_ORG/PROJECT/URL are wrong) while the build still went green. Gate silent on whether an auth token is actually configured, so the upload is verbose exactly when it runs (the CI image build) and quiet locally where no credentials are present.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Sentry source-map upload logs visible during Docker image builds by gating `silent` on the presence of an auth token instead of `process.env.CI`. This prevents hidden CI failures (e.g., 422 "Unknown project") while keeping local builds quiet.

- **Bug Fixes**
  - Set `silent: !sourceMapUploadConfig.authToken` so logs appear only when uploads actually run (CI with credentials).
  - Works around `CI` not being propagated into the Docker build, which previously hid Sentry errors.

<sup>Written for commit fd9791768cabf24d552f8faceeedfd71013808bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zemio-co/zemio/pull/136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

