### PR TITLE
feat(web): update admin reports ui

### DIFF
--- a/apps/web/src/app/(app)/admin/page.tsx
+++ b/apps/web/src/app/(app)/admin/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import { PageDescription, PageTitle } from "@/components/page-title";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+import { AdminReportsContent } from "@/modules/admin";
 import { api, HydrateClient } from "@/trpc/server";
 import { ReportsList } from "./data-display/reports-list";
 
@@ -11,34 +12,37 @@ export default async function ServerPage() {
 	void api.admin.listAllPaginated.prefetchInfinite({ limit: 50 });
 
 	return (
-		<HydrateClient>
-			<section
-				className={cn(
-					"container mt-12 flex flex-col flex-wrap items-start justify-start gap-4 sm:flex-row",
-				)}
-			>
-				<div>
-					<PageTitle>Admin Dashboard</PageTitle>
-					<PageDescription className="mt-2">
-						Verwalte deine Spesenanträge
-					</PageDescription>
-				</div>
-			</section>
-			<section className="mt-8">
-				<Suspense
-					fallback={
-						<div className="container space-y-2">
-							<Skeleton className="h-10 w-full" />
-							<Skeleton className="h-10 w-full" />
-							<Skeleton className="h-10 w-full" />
-							<Skeleton className="h-10 w-full" />
-							<Skeleton className="h-10 w-full" />
-						</div>
-					}
+		<>
+			<AdminReportsContent />
+			<HydrateClient>
+				<section
+					className={cn(
+						"container mt-12 flex flex-col flex-wrap items-start justify-start gap-4 sm:flex-row",
+					)}
 				>
-					<ReportsList />
-				</Suspense>
-			</section>
-		</HydrateClient>
+					<div>
+						<PageTitle>Admin Dashboard</PageTitle>
+						<PageDescription className="mt-2">
+							Verwalte deine Spesenanträge
+						</PageDescription>
+					</div>
+				</section>
+				<section className="mt-8">
+					<Suspense
+						fallback={
+							<div className="container space-y-2">
+								<Skeleton className="h-10 w-full" />
+								<Skeleton className="h-10 w-full" />
+								<Skeleton className="h-10 w-full" />
+								<Skeleton className="h-10 w-full" />
+								<Skeleton className="h-10 w-full" />
+							</div>
+						}
+					>
+						<ReportsList />
+					</Suspense>
+				</section>
+			</HydrateClient>
+		</>
 	);
 }

--- a/apps/web/src/lib/routes.ts
+++ b/apps/web/src/lib/routes.ts
@@ -13,7 +13,7 @@ export const ROUTES = {
 	SETTINGS_ADMIN_ORG_DETAILS: (id: string) => `/settings/admin/orgs/${id}`,
 
 	ADMIN_REVIEW_REPORT: (reportId: string) => `/admin/review/${reportId}`,
-	ADMIN_REVIEW_OVERVIEW: () => "/admin/review",
+	ADMIN_REVIEW_OVERVIEW: () => "/admin",
 
 	USER_REPORTS_LIST: () => "/reports",
 	USER_REPORT_DETAILS: (reportId: string) => `/reports/${reportId}`,

--- a/apps/web/src/modules/admin/components/admin-reports-content.tsx
+++ b/apps/web/src/modules/admin/components/admin-reports-content.tsx
@@ -1,0 +1,19 @@
+import { cn } from "@/lib/utils";
+import { AdminReportsNavbar } from "./admin-reports-navbar";
+
+function AdminReportsContent({
+	className,
+	...props
+}: React.ComponentProps<"div">) {
+	return (
+		<div
+			className={cn("", className)}
+			data-slot="admin-reports-content"
+			{...props}
+		>
+			<AdminReportsNavbar />
+		</div>
+	);
+}
+
+export { AdminReportsContent };

--- a/apps/web/src/modules/admin/components/admin-reports-navbar.tsx
+++ b/apps/web/src/modules/admin/components/admin-reports-navbar.tsx
@@ -1,24 +1,34 @@
+import Link from "next/link";
 import { Navbar, NavbarSidebarTrigger } from "@/components/navbar";
 import {
 	Breadcrumb,
 	BreadcrumbItem,
+	BreadcrumbLink,
 	BreadcrumbList,
 	BreadcrumbPage,
+	BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
+import { ROUTES } from "@/lib/routes";
 import { cn } from "@/lib/utils";
 
-function DashboardNavbar({
+function AdminReportsNavbar({
 	className,
 	...props
 }: React.ComponentProps<typeof Navbar>) {
 	return (
-		<Navbar className={cn("", className)} data-slot="dashboard-navbar" {...props}>
+		<Navbar className={cn("", className)} data-slot="component" {...props}>
 			<div className="container flex max-w-none items-center justify-start">
 				<NavbarSidebarTrigger className={"mr-4"} />
 				<Breadcrumb>
 					<BreadcrumbList>
 						<BreadcrumbItem>
-							<BreadcrumbPage>Dashboard</BreadcrumbPage>
+							<BreadcrumbLink
+								render={<Link href={ROUTES.ADMIN_REVIEW_OVERVIEW()}>Admin</Link>}
+							/>
+						</BreadcrumbItem>
+						<BreadcrumbSeparator />
+						<BreadcrumbItem>
+							<BreadcrumbPage>Reports</BreadcrumbPage>
 						</BreadcrumbItem>
 					</BreadcrumbList>
 				</Breadcrumb>
@@ -27,4 +37,4 @@ function DashboardNavbar({
 	);
 }
 
-export { DashboardNavbar };
+export { AdminReportsNavbar };

--- a/apps/web/src/modules/admin/components/index.ts
+++ b/apps/web/src/modules/admin/components/index.ts
@@ -1,3 +1,5 @@
 export * from "./admin-layout";
 export * from "./admin-org-details";
 export * from "./admin-orgs-content";
+
+export { AdminReportsContent } from "./admin-reports-content";

--- a/apps/web/src/modules/admin/index.ts
+++ b/apps/web/src/modules/admin/index.ts
@@ -1,1 +1,2 @@
 export * from "./components";
+export { AdminReportsContent } from "./components";

--- a/apps/web/src/modules/review/components/review-navbar.tsx
+++ b/apps/web/src/modules/review/components/review-navbar.tsx
@@ -13,7 +13,15 @@ import {
 import Link from "next/link";
 import React from "react";
 import { toast } from "sonner";
-import { Navbar } from "@/components/navbar";
+import { Navbar, NavbarSidebarTrigger } from "@/components/navbar";
+import {
+	Breadcrumb,
+	BreadcrumbItem,
+	BreadcrumbLink,
+	BreadcrumbList,
+	BreadcrumbPage,
+	BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import {
@@ -24,13 +32,13 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Kbd } from "@/components/ui/kbd";
-import { SidebarTrigger } from "@/components/ui/sidebar";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { ROUTES } from "@/lib/routes";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/react";
 
@@ -59,15 +67,27 @@ function ReviewNavbar({
 	if (isPending) {
 		return (
 			<Navbar className={cn("", className)} {...props}>
-				<div className="container flex items-center justify-start gap-4 py-4">
-					<SidebarTrigger />
-					<div className="flex w-fit items-center justify-center gap-3">
-						<Link className="font-medium text-sm text-zinc-600" href={"#"}>
-							Reports
-						</Link>
-						<p className="font-medium text-xs text-zinc-400">/</p>
-						<Skeleton className="h-4 w-16" />
-					</div>
+				<div className="container flex max-w-none items-center justify-start gap-4 py-4">
+					<NavbarSidebarTrigger />
+					<Breadcrumb>
+						<BreadcrumbList>
+							<BreadcrumbItem>
+								<BreadcrumbLink
+									render={<Link href={ROUTES.ADMIN_REVIEW_OVERVIEW()}>Admin</Link>}
+								/>
+							</BreadcrumbItem>
+							<BreadcrumbSeparator />
+							<BreadcrumbItem>
+								<BreadcrumbLink
+									render={<Link href={ROUTES.ADMIN_REVIEW_OVERVIEW()}>Reports</Link>}
+								/>
+							</BreadcrumbItem>
+							<BreadcrumbSeparator />
+							<BreadcrumbItem>
+								<Skeleton className="h-4 w-16" />
+							</BreadcrumbItem>
+						</BreadcrumbList>
+					</Breadcrumb>
 					<Navigation className="ml-auto" />
 				</div>
 			</Navbar>
@@ -89,17 +109,27 @@ function ReviewNavbar({
 
 	return (
 		<Navbar className={cn("", className)} {...props}>
-			<div className="container flex items-center justify-start gap-4 py-4">
-				<SidebarTrigger />
-				<div className="flex w-fit items-center justify-center gap-3">
-					<Link className="font-medium text-sm text-zinc-600" href={"#"}>
-						Reports
-					</Link>
-					<p className="font-medium text-xs text-zinc-400">/</p>
-					<Link className="font-medium text-sm text-zinc-800" href={"#"}>
-						{`#${navbarReport.readableId}`}
-					</Link>
-				</div>
+			<div className="container flex max-w-none items-center justify-start gap-4 py-4">
+				<NavbarSidebarTrigger />
+				<Breadcrumb>
+					<BreadcrumbList>
+						<BreadcrumbItem>
+							<BreadcrumbLink
+								render={<Link href={ROUTES.ADMIN_REVIEW_OVERVIEW()}>Admin</Link>}
+							/>
+						</BreadcrumbItem>
+						<BreadcrumbSeparator />
+						<BreadcrumbItem>
+							<BreadcrumbLink
+								render={<Link href={ROUTES.ADMIN_REVIEW_OVERVIEW()}>Reports</Link>}
+							/>
+						</BreadcrumbItem>
+						<BreadcrumbSeparator />
+						<BreadcrumbItem>
+							<BreadcrumbPage>#{navbarReport.readableId}</BreadcrumbPage>
+						</BreadcrumbItem>
+					</BreadcrumbList>
+				</Breadcrumb>
 				<MoreMenu report={navbarReport} />
 				<Navigation className="ml-auto" />
 			</div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Admin Reports UI with a new navbar and breadcrumbs, and standardized the review navbar to match. The admin overview route now uses /admin to simplify navigation.

- **New Features**
  - Added `AdminReportsNavbar` with breadcrumb: Admin > Reports.
  - Added `AdminReportsContent` and mounted it on `/admin`.
  - Updated review navbar to use breadcrumbs and `NavbarSidebarTrigger`.

- **Migration**
  - `ROUTES.ADMIN_REVIEW_OVERVIEW` now returns `/admin`. Update any hardcoded `/admin/review` links.

<sup>Written for commit a67c442d9ff79536953858ce040fd3b525d1dc63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zemio-co/zemio/pull/137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

