### PR TITLE
fix(web): stabilize dialog handles

### DIFF
--- a/apps/web/src/modules/report/components/create-expense.tsx
+++ b/apps/web/src/modules/report/components/create-expense.tsx
@@ -48,7 +48,12 @@ function CreateExpense({
 }: React.ComponentProps<typeof Button> & {
 	reportId: string;
 }) {
-	const receiptHandle = useRef(Dialog.createHandle()).current;
+	const receiptHandleRef = useRef<ReturnType<typeof Dialog.createHandle> | null>(
+		null,
+	);
+	if (!receiptHandleRef.current)
+		receiptHandleRef.current = Dialog.createHandle();
+	const receiptHandle = receiptHandleRef.current;
 
 	return (
 		<>

--- a/apps/web/src/modules/report/components/create-expense.tsx
+++ b/apps/web/src/modules/report/components/create-expense.tsx
@@ -5,6 +5,7 @@ import { useForm } from "@tanstack/react-form";
 import { formatDate, isValid, parse } from "date-fns";
 import { CarIcon, ReceiptIcon, UtensilsIcon, XIcon } from "lucide-react";
 import type React from "react";
+import { useRef } from "react";
 import { toast } from "sonner";
 import z from "zod";
 import { DatePicker } from "@/components/date-picker";
@@ -47,7 +48,7 @@ function CreateExpense({
 }: React.ComponentProps<typeof Button> & {
 	reportId: string;
 }) {
-	const receiptHandle = Dialog.createHandle();
+	const receiptHandle = useRef(Dialog.createHandle()).current;
 
 	return (
 		<>

--- a/apps/web/src/modules/report/components/report-expenses.tsx
+++ b/apps/web/src/modules/report/components/report-expenses.tsx
@@ -13,6 +13,7 @@ import {
 	ReceiptIcon,
 	TrashIcon,
 } from "lucide-react";
+import { useRef } from "react";
 import { toast } from "sonner";
 import {
 	AlertDialog,
@@ -246,8 +247,8 @@ function ExpenseActionMenu({
 	expenseId: string;
 	reportId: string;
 }) {
-	const deleteHandle = AlertDialogPrimitive.createHandle();
-	const editHandle = DialogPrimitive.createHandle();
+	const deleteHandle = useRef(AlertDialogPrimitive.createHandle()).current;
+	const editHandle = useRef(DialogPrimitive.createHandle()).current;
 
 	return (
 		<>

--- a/apps/web/src/modules/report/components/report-expenses.tsx
+++ b/apps/web/src/modules/report/components/report-expenses.tsx
@@ -247,8 +247,19 @@ function ExpenseActionMenu({
 	expenseId: string;
 	reportId: string;
 }) {
-	const deleteHandle = useRef(AlertDialogPrimitive.createHandle()).current;
-	const editHandle = useRef(DialogPrimitive.createHandle()).current;
+	const deleteHandleRef = useRef<ReturnType<
+		typeof AlertDialogPrimitive.createHandle
+	> | null>(null);
+	if (!deleteHandleRef.current)
+		deleteHandleRef.current = AlertDialogPrimitive.createHandle();
+	const deleteHandle = deleteHandleRef.current;
+
+	const editHandleRef = useRef<ReturnType<
+		typeof DialogPrimitive.createHandle
+	> | null>(null);
+	if (!editHandleRef.current)
+		editHandleRef.current = DialogPrimitive.createHandle();
+	const editHandle = editHandleRef.current;
 
 	return (
 		<>

--- a/apps/web/src/modules/report/components/report-header.tsx
+++ b/apps/web/src/modules/report/components/report-header.tsx
@@ -379,8 +379,10 @@ function ReportHeaderEditAction({
 }: React.ComponentProps<typeof Button> & {
 	report: Report;
 }) {
-	const editTitleHandle = AlertDialogPrimitive.createHandle();
-	const deleteHandle = AlertDialogPrimitive.createHandle();
+	const editTitleHandle = React.useRef(
+		AlertDialogPrimitive.createHandle(),
+	).current;
+	const deleteHandle = React.useRef(AlertDialogPrimitive.createHandle()).current;
 
 	const disabledByStatus = React.useMemo(() => {
 		return !(report.status === "DRAFT" || report.status === "NEEDS_REVISION");
@@ -588,9 +590,7 @@ function ReportHeaderSubmitAction({
 	report: Report;
 }) {
 	const utils = api.useUtils();
-	const handle = React.useMemo(() => {
-		return AlertDialogPrimitive.createHandle();
-	}, []);
+	const handle = React.useRef(AlertDialogPrimitive.createHandle()).current;
 
 	const disabledByStatus = React.useMemo(() => {
 		return !(report.status === "DRAFT" || report.status === "NEEDS_REVISION");

--- a/apps/web/src/modules/report/components/report-header.tsx
+++ b/apps/web/src/modules/report/components/report-header.tsx
@@ -379,10 +379,19 @@ function ReportHeaderEditAction({
 }: React.ComponentProps<typeof Button> & {
 	report: Report;
 }) {
-	const editTitleHandle = React.useRef(
-		AlertDialogPrimitive.createHandle(),
-	).current;
-	const deleteHandle = React.useRef(AlertDialogPrimitive.createHandle()).current;
+	const editTitleHandleRef = React.useRef<ReturnType<
+		typeof AlertDialogPrimitive.createHandle
+	> | null>(null);
+	if (!editTitleHandleRef.current)
+		editTitleHandleRef.current = AlertDialogPrimitive.createHandle();
+	const editTitleHandle = editTitleHandleRef.current;
+
+	const deleteHandleRef = React.useRef<ReturnType<
+		typeof AlertDialogPrimitive.createHandle
+	> | null>(null);
+	if (!deleteHandleRef.current)
+		deleteHandleRef.current = AlertDialogPrimitive.createHandle();
+	const deleteHandle = deleteHandleRef.current;
 
 	const disabledByStatus = React.useMemo(() => {
 		return !(report.status === "DRAFT" || report.status === "NEEDS_REVISION");
@@ -590,7 +599,12 @@ function ReportHeaderSubmitAction({
 	report: Report;
 }) {
 	const utils = api.useUtils();
-	const handle = React.useRef(AlertDialogPrimitive.createHandle()).current;
+	const handleRef = React.useRef<ReturnType<
+		typeof AlertDialogPrimitive.createHandle
+	> | null>(null);
+	if (!handleRef.current)
+		handleRef.current = AlertDialogPrimitive.createHandle();
+	const handle = handleRef.current;
 
 	const disabledByStatus = React.useMemo(() => {
 		return !(report.status === "DRAFT" || report.status === "NEEDS_REVISION");


### PR DESCRIPTION
stabilize dialog handles with useRef to prevent stuck overlays

Handles created with Dialog.createHandle() / AlertDialog.createHandle() inside a component render function are recreated on every render. When a re-render occurs while a dialog is open (e.g. mutation isPending change), the dialog root receives a new handle instance that has no knowledge of the open state, causing the overlay to become unresponsive.

Replace all bare createHandle() calls and the one useMemo-based workaround with useRef so each component instance holds a single stable handle for its lifetime.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilized dialog and alert dialog handles with a lazy `useRef` pattern so each component instance keeps a single handle and overlays don’t get stuck on re-render. Prevents dialogs becoming unresponsive when state changes while open.

- **Bug Fixes**
  - Replaced `Dialog.createHandle()`, `AlertDialog.createHandle()`, `DialogPrimitive.createHandle()`, and `AlertDialogPrimitive.createHandle()` with a lazy `useRef` (init once, reuse across renders).
  - Removed the `useMemo` workaround in `ReportHeaderSubmitAction` in favor of the lazy-ref handle.
  - Updated files: `create-expense.tsx`, `report-expenses.tsx`, `report-header.tsx`.

<sup>Written for commit 456d0364bf4239808555c3a9c14794060d6e1880. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zemio-co/zemio/pull/149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

