### PR TITLE
feat(web): install agentation

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,6 +38,7 @@
 		"@zemio/db": "workspace:*",
 		"@zemio/encryption": "workspace:*",
 		"@zemio/logger": "workspace:*",
+		"agentation": "^3.0.2",
 		"better-auth": "^1.6.14",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "@/styles/globals.css";
 
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { Agentation } from "agentation";
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import { Providers } from "@/components/providers";
@@ -58,6 +59,9 @@ export default function RootLayout({
 					<TRPCReactProvider>
 						{children}
 						<ReactQueryDevtools />
+						{process.env.NODE_ENV === "development" && (
+							<Agentation endpoint="http://localhost:4747" />
+						)}
 					</TRPCReactProvider>
 					<Toaster />
 				</Providers>

--- a/bun.lock
+++ b/bun.lock
@@ -70,6 +70,7 @@
         "@zemio/db": "workspace:*",
         "@zemio/encryption": "workspace:*",
         "@zemio/logger": "workspace:*",
+        "agentation": "^3.0.2",
         "better-auth": "^1.6.14",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -953,6 +954,8 @@
     "acorn-import-phases": ["acorn-import-phases@1.0.4", "", { "peerDependencies": { "acorn": "^8.14.0" } }, "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ=="],
 
     "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "agentation": ["agentation@3.0.2", "", { "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-iGzBxFVTuZEIKzLY6AExSLAQH6i6SwxV4pAu7v7m3X6bInZ7qlZXAwrEqyc4+EfP4gM7z2RXBF6SF4DeH0f2lA=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,10 +1,22 @@
 {
-	"version": 1,
-	"skills": {
-		"neon-postgres": {
-			"source": "neondatabase/agent-skills",
-			"sourceType": "github",
-			"computedHash": "391693eee67001639ab65474df185da3ea5cf9ee4b99badecfd64561113edbb4"
-		}
-	}
+  "version": 1,
+  "skills": {
+    "agentation": {
+      "source": "benjitaylor/agentation",
+      "sourceType": "github",
+      "skillPath": "skills/agentation/SKILL.md",
+      "computedHash": "6ba2c955bee6ab3e9c7781b2553e3574b4c9ec35e539437d0831bfe368de8550"
+    },
+    "agentation-self-driving": {
+      "source": "benjitaylor/agentation",
+      "sourceType": "github",
+      "skillPath": "skills/agentation-self-driving/SKILL.md",
+      "computedHash": "4a543f93d3edc770a684aa554321ca113debc74b276e1cdc4b8a5a8c44932ab7"
+    },
+    "neon-postgres": {
+      "source": "neondatabase/agent-skills",
+      "sourceType": "github",
+      "computedHash": "391693eee67001639ab65474df185da3ea5cf9ee4b99badecfd64561113edbb4"
+    }
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `agentation` to the web app and enable the Agentation panel in development at `http://localhost:4747`. Registers `agentation` skills for upcoming agent workflows.

- **New Features**
  - Render `<Agentation endpoint="http://localhost:4747" />` in `RootLayout` when `NODE_ENV === "development"`.
  - Add `agentation` and `agentation-self-driving` entries to `skills-lock.json`.

- **Dependencies**
  - Add `agentation@^3.0.2` to `apps/web` and update `bun.lock`.

<sup>Written for commit 7824a2229a9ed24f32c46c371a8bbd65fa4654ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zemio-co/zemio/pull/150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

