### PR TITLE
fix(web): remove scrollbar on reports list during load

### DIFF
--- a/apps/web/src/modules/dashboard/components/dashboard-report-list.tsx
+++ b/apps/web/src/modules/dashboard/components/dashboard-report-list.tsx
@@ -27,7 +27,7 @@ function DashboardReportList({
 	if (isPending) {
 		return (
 			<section
-				className={cn("max-w-full space-y-4 overflow-x-auto", className)}
+				className={cn("max-w-full space-y-4", className)}
 				data-slot="dashboard-report-list"
 				{...props}
 			>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove the horizontal scrollbar on the reports list while loading by dropping `overflow-x-auto` from the loading state container in DashboardReportList. Addresses ZEM-9 by preventing the unnecessary scrollbar during the pending state.

<sup>Written for commit 239f058adfa472b864a625d93b1b572968e481c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zemio-co/zemio/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

