### PR TITLE
fix(web): improve spacing on expenses table

### DIFF
--- a/apps/web/src/modules/report/components/report-expenses.tsx
+++ b/apps/web/src/modules/report/components/report-expenses.tsx
@@ -104,13 +104,13 @@ function ReportExpenses({
 					<tbody>
 						{expenses.map((expense) => (
 							<tr className="border-slate-200 border-b" key={expense.id}>
-								<td className="px-2 py-2.5 pl-0 text-left font-medium text-slate-800">
+								<td className="px-3 py-2.5 pl-0 text-left font-medium text-slate-800">
 									{translateExpenseType(expense.type)}
 								</td>
-								<td className="px-2 py-2.5 text-left text-slate-700 text-sm">
+								<td className="px-3 py-2.5 text-left text-slate-700 text-sm">
 									{expense.description}
 								</td>
-								<td className="px-2 py-2.5 text-left text-slate-700 text-sm">
+								<td className="px-3 py-2.5 text-left text-slate-700 text-sm">
 									{isSameDay(expense.startDate, expense.endDate) ? (
 										formatDate(expense.startDate, "dd.MM.yyyy")
 									) : (
@@ -120,7 +120,7 @@ function ReportExpenses({
 										</>
 									)}
 								</td>
-								<td className="px-2 py-2.5 text-right font-semibold text-slate-700 text-sm">
+								<td className="whitespace-nowrap px-3 py-2.5 text-right font-semibold text-slate-700 text-sm">
 									{expense.amount.toFixed(2)} <span className="ml-1">€</span>
 								</td>
 								<td className="pl-2">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improved spacing in the report expenses table and prevented the amount column from wrapping to make values easier to scan. Addresses Linear ZEM-7 by increasing horizontal cell padding and adding a no-wrap style to the amount cell so the value and € stay on one line.

<sup>Written for commit b35be1ca057fead571f9271543bb03ad99c26598. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zemio-co/zemio/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

