### PR TITLE
feat(web): enabled attachment download for users

### DIFF
--- a/apps/web/src/modules/report/components/report-attachments.tsx
+++ b/apps/web/src/modules/report/components/report-attachments.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { Attachment } from "@zemio/db";
-import { FileIcon, TrashIcon } from "lucide-react";
+import { DownloadIcon, FileIcon, TrashIcon } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -148,6 +148,7 @@ function AttachmentRow({
 	reportId: string;
 }) {
 	const utils = api.useUtils();
+	const downloadMutation = api.attachment.getDownloadUrl.useMutation();
 	const deleteMutation = api.attachment.delete.useMutation({
 		onSuccess: () => {
 			toast.success("Anhang erfolgreich gelöscht.");
@@ -165,6 +166,24 @@ function AttachmentRow({
 			id: attachment.id,
 		});
 	};
+
+	function handleDownload() {
+		toast.promise(
+			downloadMutation.mutateAsync({ id: attachment.id }).then((result) => {
+				window.location.href = result.url;
+			}),
+			{
+				loading: "Download wird vorbereitet…",
+				success: "Download gestartet",
+				error: (error) => {
+					return {
+						message: "Fehler beim Herunterladen des Anhangs",
+						description: error.message ?? "Ein unbekannter Fehler ist aufgetreten",
+					};
+				},
+			},
+		);
+	}
 
 	return (
 		<li
@@ -185,7 +204,18 @@ function AttachmentRow({
 				</p>
 				<p className="text-slate-500 text-xs">{formatBytes(attachment.size)}</p>
 			</div>
-			<div className="ml-8">
+			<div className="ml-8 flex items-center justify-center gap-2">
+				<Button
+					className={
+						"opacity-0 transition-opacity group-hover/row:opacity-100 group-data-[pending=true]/row:opacity-100"
+					}
+					disabled={deleteMutation.isPending}
+					onClick={handleDownload}
+					size={"icon-sm"}
+					variant={"ghost"}
+				>
+					<DownloadIcon />
+				</Button>
 				<Button
 					className={
 						"opacity-0 transition-opacity group-hover/row:opacity-100 group-data-[pending=true]/row:opacity-100"
@@ -195,7 +225,7 @@ function AttachmentRow({
 					size={"icon-sm"}
 					variant={"ghost"}
 				>
-					<TrashIcon />
+					<TrashIcon className="text-destructive" />
 				</Button>
 			</div>
 		</li>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable downloading report attachments directly from the list. Adds a download action that fetches a secure URL and starts the browser download with clear toasts (ZEM-8).

- **New Features**
  - Download button on each attachment row using `api.attachment.getDownloadUrl.useMutation()`.
  - Shows loading/success/error toasts; starts download via returned `url`.
  - UI polish: delete icon uses destructive color; action buttons appear on hover or when pending.

<sup>Written for commit 38005701edebcebc4f65054e3b8cc680c50e3ca3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zemio-co/zemio/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

