### PR TITLE
fix(web): disable click animations on filter menu

### DIFF
--- a/apps/web/src/app/(app)/admin/reports/data-display/reports-list.tsx
+++ b/apps/web/src/app/(app)/admin/reports/data-display/reports-list.tsx
@@ -222,6 +222,7 @@ export function ReportsList() {
 				<FilterList className="grow" table={table}>
 					<FilterMenu
 						className={"group/filter-menu data-[filtered=true]:size-6"}
+						disableAnimation
 						size={"xs"}
 						table={table}
 						variant={"outline"}
@@ -234,6 +235,7 @@ export function ReportsList() {
 				</FilterList>
 				<DisplayOptions
 					className={"shrink-0"}
+					disableAnimation
 					display={table}
 					size={"sm"}
 					variant={"outline"}

--- a/apps/web/src/components/data/filter-registry.tsx
+++ b/apps/web/src/components/data/filter-registry.tsx
@@ -174,7 +174,7 @@ function DateRangeChipContent<TData, TValue>({
 			<DropdownMenu>
 				<DropdownMenuTrigger
 					render={
-						<Button size="xs" variant="outline">
+						<Button disableAnimation size="xs" variant="outline">
 							{daysLabel}
 						</Button>
 					}
@@ -191,7 +191,7 @@ function DateRangeChipContent<TData, TValue>({
 				</DropdownMenuContent>
 			</DropdownMenu>
 
-			<Button onClick={onRemove} size="icon-xs" variant="outline">
+			<Button disableAnimation onClick={onRemove} size="icon-xs" variant="outline">
 				<XIcon />
 				<span className="sr-only">Filter entfernen</span>
 			</Button>
@@ -305,7 +305,7 @@ function SelectChipContent<TData, TValue>({
 			<DropdownMenu>
 				<DropdownMenuTrigger
 					render={
-						<Button size="xs" variant="outline">
+						<Button disableAnimation size="xs" variant="outline">
 							{value.operator === "is" ? "ist" : "ist nicht"}
 						</Button>
 					}
@@ -324,7 +324,7 @@ function SelectChipContent<TData, TValue>({
 			<DropdownMenu>
 				<DropdownMenuTrigger
 					render={
-						<Button size="xs" variant="outline">
+						<Button disableAnimation size="xs" variant="outline">
 							{selectedOption?.icon && (
 								<selectedOption.icon className={selectedOption.iconClassName} />
 							)}
@@ -505,7 +505,7 @@ function MultiSelectChipContent<TData, TValue>({
 			<DropdownMenu>
 				<DropdownMenuTrigger
 					render={
-						<Button size="xs" variant="outline">
+						<Button disableAnimation size="xs" variant="outline">
 							{value.operator === "in" ? "enthält" : "enthält nicht"}
 						</Button>
 					}
@@ -524,7 +524,7 @@ function MultiSelectChipContent<TData, TValue>({
 			<DropdownMenu>
 				<DropdownMenuTrigger
 					render={
-						<Button size="xs" variant="outline">
+						<Button disableAnimation size="xs" variant="outline">
 							{selectedOptions.length === 1 && FirstOptionIcon && (
 								<FirstOptionIcon className={firstSelectedOption?.iconClassName} />
 							)}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable click animations across the filter UI to remove flicker and visual noise when opening menus or removing chips in the admin reports list.

- **Bug Fixes**
  - Added `disableAnimation` to `FilterMenu` and `DisplayOptions` in the reports list.
  - Disabled animations on chip buttons and dropdown triggers in `filter-registry.tsx` (date range, select, multi-select).

<sup>Written for commit 0709ad6ccb9f8751cfa5935443f1bf7d1a0b3e63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zemio-co/zemio/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

