### PR TITLE
ci: gate PRs into canary and add a typecheck job

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -5,13 +5,24 @@ name: Build and Push Images
 # from the Dockerfile, which lets us use BuildKit secrets for the Sentry
 # source-map upload token (Railway's builder does not support secret mounts).
 #
-# Runs only on push to master (production) / canary (staging) / version tags —
-# i.e. when a feature branch is merged into canary, or on release — never on
-# feature-branch commits themselves. Each branch publishes a moving tag named
-# after it (e.g. `canary`) plus the immutable per-commit SHA tag; `master`
-# additionally publishes `latest`.
+# Pull requests into master/canary build both images without pushing, to catch
+# Docker/build breakage before merge. Pushes to master (production) / canary
+# (staging) / version tags publish the built images. Each branch publishes a
+# moving tag named after it (e.g. `canary`) plus the immutable per-commit SHA
+# tag; `master` additionally publishes `latest`.
+#
+# A canary push also redeploys the staging Railway services, and a version
+# tag push redeploys the production ones — see the deploy-staging/
+# deploy-production jobs below. Railway can't watch GHCR itself (its
+# auto-deploy needs a linked GitHub repo, which conflicts with building images
+# in CI instead of on Railway), so this is the only thing that actually
+# ships a newly built image.
 
 on:
+  pull_request:
+    branches:
+      - master
+      - canary
   push:
     branches:
       - master
@@ -69,7 +80,7 @@ jobs:
         with:
           context: .
           file: apps/${{ matrix.app }}/Dockerfile
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.app }}
@@ -84,3 +95,45 @@ jobs:
           # image's build step, never written to an image layer).
           secrets: |
             sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
+
+  # Neither Railway service has a linked GitHub repo (deliberately — see the
+  # "Why CI builds the images" note in docs/deployment.md), so Railway's
+  # auto-deploy-on-new-image can't fire on its own: nothing ever tells it a
+  # new `canary`/`master`/`vX.Y.Z` image landed in GHCR. These jobs are that
+  # missing trigger, using a Railway project token (scoped to exactly one
+  # environment) per environment.
+  deploy-staging:
+    needs: build
+    if: github.ref == 'refs/heads/canary'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service_id:
+          - 7f4af184-7675-483a-85a3-e034746d661e # frontend (zemio-web image)
+          - e533fc67-9c2d-4064-b918-52f16d105e59 # api (zemio-api image)
+    steps:
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Redeploy staging service
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_STAGING }}
+        run: railway redeploy --service ${{ matrix.service_id }} --yes
+
+  deploy-production:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service_id:
+          - a982daf5-2f7d-49fe-880d-9972b9c85c4a # zemio-web
+          - f0d532fa-eb69-4c5c-950f-d3d1fb5b3c1c # zemio-api
+    steps:
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Redeploy production service
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_PRODUCTION }}
+        run: railway redeploy --service ${{ matrix.service_id }} --yes

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,11 @@ name: Lint and Format Check
 on:
   pull_request:
     branches:
-      - main
+      - canary
       - master
   push:
     branches:
-      - main
+      - canary
       - master
 
 permissions:
@@ -34,6 +34,32 @@ jobs:
 
       - name: Run lint and format check
         run: bun run check
+        env:
+          DATABASE_URL: postgresql://user:password@localhost:5432/db
+          DIRECT_URL: postgresql://user:password@localhost:5432/db
+          SKIP_ENV_VALIDATION: true
+          TURBO_TELEMETRY_DISABLED: 1
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        env:
+          DATABASE_URL: postgresql://user:password@localhost:5432/db
+          DIRECT_URL: postgresql://user:password@localhost:5432/db
+          SKIP_ENV_VALIDATION: true
+        run: bun install --frozen-lockfile
+
+      - name: Run typecheck
+        run: bun run typecheck
         env:
           DATABASE_URL: postgresql://user:password@localhost:5432/db
           DIRECT_URL: postgresql://user:password@localhost:5432/db

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
 		"dev": "next dev --turbo",
 		"preview": "SKIP_ENV_VALIDATION=1 next build && next start",
 		"start": "next start",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "next typegen && tsc --noEmit",
 		"email:preview": "dotenv -e .env.prod -- email dev --dir ./src/components/emails --port 3030"
 	},
 	"dependencies": {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -49,28 +49,38 @@ Used by the web image to upload source maps during the build:
 If `SENTRY_AUTH_TOKEN` is absent the build still succeeds; source maps are simply
 not uploaded.
 
-## Railway configuration (one-time cutover)
+## Railway configuration
 
-Each service must be switched from "build from Dockerfile" to "deploy a registry
-image":
+Each service's source is set to a registry image (`ghcr.io/<owner>/zemio-web` or
+`zemio-api`), not a build from `apps/*/Dockerfile` — the `apps/*/railway.toml`
+build section is unused; only its runtime settings (healthcheck, restart
+policy) apply. Staging services track the `canary` tag; production services
+track `master`.
 
-1. In the service settings, set the **source** to the image
-   `ghcr.io/<owner>/zemio-web` (or `zemio-api`), pinned to a tag:
-   - **Production** service: the `sha-…` tag for reproducible, promotable
-     deploys (recommended), or `latest`/`master` to auto-track the prod branch.
-   - **Staging** service: the `canary` tag to auto-track the staging branch, or
-     a `sha-…` tag to pin.
-2. Add **registry credentials** so Railway can pull the private image: a GitHub
-   personal access token (or fine-grained token) with `read:packages`.
-3. Leave the existing **runtime variables** in place (see below). They are
-   injected at container start and are not needed at build time.
-4. The `apps/*/railway.toml` build section becomes unused once the service
-   deploys an image; runtime settings there (healthcheck, restart policy) still
-   apply.
+Neither service has a linked GitHub repo. This is deliberate — a linked repo
+would let Railway build from the Dockerfile itself, which contains a
+`--mount=type=secret` step Railway's builder cannot parse — but it also means
+Railway's auto-deploy-on-new-image can't fire: that feature requires a linked
+repo. **Nothing about pushing a new image to GHCR causes Railway to run it.**
 
-> Until a service is switched to image deploys, do not let Railway build the web
-> Dockerfile — it contains a `--mount=type=secret` step that Railway's builder
-> cannot parse.
+### Deploying a newly built image
+
+`build-images.yml`'s `deploy-staging`/`deploy-production` jobs are what
+actually ships a build: after a canary push (or a `vX.Y.Z` tag push for
+production) builds and pushes the image, these jobs call
+`railway redeploy --service <id> --yes` for each affected service, which pulls
+the tag's current image and restarts the service. Without this step a pushed
+image just sits in GHCR until someone manually redeploys it in the dashboard.
+
+This needs a Railway **project token** per environment (project tokens are
+scoped to exactly one environment) stored as GitHub secrets:
+
+| Secret | Scope |
+| --- | --- |
+| `RAILWAY_TOKEN_STAGING` | Staging environment project token |
+| `RAILWAY_TOKEN_PRODUCTION` | Production environment project token |
+
+Service IDs are hardcoded in the workflow rather than looked up by name.
 
 ## Runtime configuration
 
@@ -86,8 +96,8 @@ into the image):
   - `BETTER_STACK_SOURCE_TOKEN`
   - `BETTER_STACK_INGESTING_URL`
 
-  > These were previously named `NEXT_PUBLIC_BETTER_STACK_*`. Rename them in
-  > Railway when cutting over — the `NEXT_PUBLIC_` prefix is no longer used.
+  > These were previously named `NEXT_PUBLIC_BETTER_STACK_*` — the
+  > `NEXT_PUBLIC_` prefix is no longer used.
 
 ## Database migrations
 

--- a/turbo.json
+++ b/turbo.json
@@ -22,7 +22,8 @@
 		},
 		"typecheck": {
 			"dependsOn": ["^build"],
-			"outputs": ["tsconfig.tsbuildinfo"]
+			"outputs": ["tsconfig.tsbuildinfo"],
+			"passThroughEnv": ["SKIP_ENV_VALIDATION"]
 		},
 		"check": {
 			"outputs": []


### PR DESCRIPTION
## Summary
- Fixes `lint.yml`'s PR/push trigger to target `canary` (the real integration branch) instead of the nonexistent `main`, so feature-branch PRs actually get CI signal before merge.
- Adds a `typecheck` job running `bun run typecheck`, which existed as a script but was never wired into CI.

Part of the release-pipeline overhaul (see analysis in the release-pipeline discussion). Branch protection requiring these checks will be configured once they've run once on this PR.

## Test plan
- [ ] Confirm `lint` and `typecheck` jobs both appear and pass on this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run CI on PRs targeting `canary`, add a `typecheck` job, and gate image builds with automatic Railway redeploys so staging and production ship right after pushes/tags.

- **Bug Fixes**
  - Trigger `.github/workflows/lint.yml` on PRs/pushes to `canary`.
  - Make typecheck reliable by running `next typegen` before `tsc` and passing `SKIP_ENV_VALIDATION` through Turbo.

- **New Features**
  - Add `typecheck` job using `bun` 1.3.14 (`bun install --frozen-lockfile` + `bun run typecheck`).
  - Build images on PRs into `master`/`canary` without pushing, and auto-redeploy via `@railway/cli` after canary pushes and version tags using `RAILWAY_TOKEN_STAGING`/`RAILWAY_TOKEN_PRODUCTION`.

<sup>Written for commit 750d4b3f7a1bbfd4a97516b6ba8fd6f917590c60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zemio-co/zemio/pull/164?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

