### PR TITLE
fix(web): reporting shows top 5 entries only

### DIFF
--- a/.changeset/strict-geckos-look.md
+++ b/.changeset/strict-geckos-look.md
@@ -1,0 +1,5 @@
+---
+"@zemio/web": patch
+---
+
+reporting endpoints return only top 5 entries

--- a/apps/web/src/server/modules/reporting/reporting.dto.ts
+++ b/apps/web/src/server/modules/reporting/reporting.dto.ts
@@ -64,6 +64,9 @@ export const reportingOverviewDTOSchema = z.object({
 });
 export type ReportingOverviewDTO = z.infer<typeof reportingOverviewDTOSchema>;
 
+/** Every "by…" breakdown returns at most this many rows, ranked by amount desc. */
+export const MAX_BREAKDOWN_ROWS = 5;
+
 /** One row of a grouped breakdown (by cost unit / member / expense type / status). */
 export const reportingBreakdownRowSchema = z.object({
 	key: z.string(),

--- a/apps/web/src/server/modules/reporting/reporting.repository.ts
+++ b/apps/web/src/server/modules/reporting/reporting.repository.ts
@@ -6,7 +6,7 @@ import {
 } from "@zemio/db";
 import { reportRepository } from "@/server/modules/report";
 import { nullableDecimalToNumber } from "@/server/shared/money";
-import type { Granularity } from "./reporting.dto";
+import { type Granularity, MAX_BREAKDOWN_ROWS } from "./reporting.dto";
 
 type Db = PrismaClient;
 
@@ -102,6 +102,8 @@ export const reportingRepository = {
 			where: { report: where },
 			_sum: { amount: true },
 			_count: true,
+			orderBy: { _sum: { amount: "desc" } },
+			take: MAX_BREAKDOWN_ROWS,
 		});
 
 		return rows.map((row) => ({

--- a/apps/web/src/server/modules/reporting/reporting.service.ts
+++ b/apps/web/src/server/modules/reporting/reporting.service.ts
@@ -9,14 +9,15 @@ import {
 	startOfPeriod,
 } from "@/server/modules/dashboard";
 import { decimalToNumber } from "@/server/shared/money";
-import type {
-	ReportingBreakdownDTO,
-	ReportingExportDTO,
-	ReportingOverviewDTO,
-	ReportingPdfExportResult,
-	ReportingPdfFilterInput,
-	ReportingTimeSeriesDTO,
-	ReportingTimeSeriesInput,
+import {
+	MAX_BREAKDOWN_ROWS,
+	type ReportingBreakdownDTO,
+	type ReportingExportDTO,
+	type ReportingOverviewDTO,
+	type ReportingPdfExportResult,
+	type ReportingPdfFilterInput,
+	type ReportingTimeSeriesDTO,
+	type ReportingTimeSeriesInput,
 } from "./reporting.dto";
 import { type ReportingFilterInput, reportingWhere } from "./reporting.query";
 import {
@@ -68,6 +69,20 @@ function bucketReportsBy<K extends string>(args: {
 	}
 
 	return buckets;
+}
+
+/**
+ * Ranks bucketed breakdown entries by amount descending and caps them at
+ * `MAX_BREAKDOWN_ROWS` — the buckets are built from an unordered `Map`
+ * (insertion order), so callers must not rely on iteration order.
+ */
+function rankBuckets<K, V extends Bucket>(
+	buckets: Map<K, V>,
+	limit = MAX_BREAKDOWN_ROWS,
+): [K, V][] {
+	return [...buckets.entries()]
+		.sort(([, a], [, b]) => b.amount - a.amount)
+		.slice(0, limit);
 }
 
 async function reportsWithSums(args: {
@@ -196,11 +211,11 @@ export function createReportingService(deps: { repo: ReportingRepository }) {
 		): Promise<ReportingBreakdownDTO> {
 			const buckets = await statusBuckets(repo, ctx, input);
 
-			return Object.values(ReportStatus).map((status) => ({
+			return rankBuckets(buckets).map(([status, bucket]) => ({
 				key: status,
 				label: translateReportStatus(status),
-				amount: buckets.get(status)?.amount ?? 0,
-				count: buckets.get(status)?.count ?? 0,
+				amount: bucket.amount,
+				count: bucket.count,
 			}));
 		},
 
@@ -221,7 +236,7 @@ export function createReportingService(deps: { repo: ReportingRepository }) {
 				labelOf: (report) => `${report.costUnit.tag} · ${report.costUnit.title}`,
 			});
 
-			return [...buckets.entries()].map(([key, bucket]) => ({
+			return rankBuckets(buckets).map(([key, bucket]) => ({
 				key,
 				label: bucket.label,
 				amount: bucket.amount,
@@ -246,7 +261,7 @@ export function createReportingService(deps: { repo: ReportingRepository }) {
 				labelOf: (report) => report.owner.name,
 			});
 
-			return [...buckets.entries()].map(([key, bucket]) => ({
+			return rankBuckets(buckets).map(([key, bucket]) => ({
 				key,
 				label: bucket.label,
 				amount: bucket.amount,

--- a/apps/web/src/server/modules/reporting/reporting.service.ts
+++ b/apps/web/src/server/modules/reporting/reporting.service.ts
@@ -74,14 +74,18 @@ function bucketReportsBy<K extends string>(args: {
 /**
  * Ranks bucketed breakdown entries by amount descending and caps them at
  * `MAX_BREAKDOWN_ROWS` — the buckets are built from an unordered `Map`
- * (insertion order), so callers must not rely on iteration order.
+ * (insertion order), so callers must not rely on iteration order. Ties break
+ * on `key` so the ranking is deterministic across requests regardless of the
+ * unordered fetch that populated the buckets.
  */
-function rankBuckets<K, V extends Bucket>(
+function rankBuckets<K extends string, V extends Bucket>(
 	buckets: Map<K, V>,
 	limit = MAX_BREAKDOWN_ROWS,
 ): [K, V][] {
 	return [...buckets.entries()]
-		.sort(([, a], [, b]) => b.amount - a.amount)
+		.sort(
+			([keyA, a], [keyB, b]) => b.amount - a.amount || keyA.localeCompare(keyB),
+		)
 		.slice(0, limit);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ranks and caps reporting breakdowns (by status, cost unit, member, expense type) to the top 5 by spend with deterministic ordering. Done server‑side so the dashboard shows the right top spenders and responses are smaller.

- **Bug Fixes**
  - Rank breakdowns by amount desc and limit to 5; apply across byStatus/byCostUnit/byMember/byExpenseType.
  - Push ORDER BY/LIMIT into Prisma for byExpenseType; rank others via a shared helper.
  - Break ties by key for stable, repeatable ordering across requests.

<sup>Written for commit 1f56113b80437dcff050ccda14b5d63f48326322. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zemio-co/zemio/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

