### PR TITLE
fix(web): hide draft reports from admins

### DIFF
--- a/.changeset/solid-pears-lie.md
+++ b/.changeset/solid-pears-lie.md
@@ -1,0 +1,5 @@
+---
+"@zemio/web": patch
+---
+
+hide draft reports from admins

--- a/apps/web/src/app/(app)/admin/reports/data-display/columns.tsx
+++ b/apps/web/src/app/(app)/admin/reports/data-display/columns.tsx
@@ -89,7 +89,7 @@ const statusColumn: ColumnDef<ExtendedReport> = {
 		);
 	},
 	filterFn: (row, _columnId, filterValue) => {
-		const { operator = "is", value = "DRAFT" } = (filterValue ??
+		const { operator = "is", value = "PENDING_APPROVAL" } = (filterValue ??
 			{}) as SelectFilterValue<ReportStatus>;
 
 		return operator === "is"
@@ -129,7 +129,6 @@ const statusColumn: ColumnDef<ExtendedReport> = {
 		icon: CircleDotDashedIcon,
 		options: (
 			[
-				"DRAFT",
 				"PENDING_APPROVAL",
 				"NEEDS_REVISION",
 				"ACCEPTED",

--- a/apps/web/src/app/(app)/admin/reports/data-display/columns.tsx
+++ b/apps/web/src/app/(app)/admin/reports/data-display/columns.tsx
@@ -89,12 +89,14 @@ const statusColumn: ColumnDef<ExtendedReport> = {
 		);
 	},
 	filterFn: (row, _columnId, filterValue) => {
-		const { operator = "is", value = "PENDING_APPROVAL" } = (filterValue ??
-			{}) as SelectFilterValue<ReportStatus>;
+		const { operator = "in", value = [] } = (filterValue ??
+			{}) as MultiSelectFilterValue<ReportStatus>;
 
-		return operator === "is"
-			? row.original.status === value
-			: row.original.status !== value;
+		if (value.length === 0) return true;
+
+		return operator === "in"
+			? value.includes(row.original.status)
+			: !value.includes(row.original.status);
 	},
 	cell: ({ row }) => {
 		const Icon = StatusIcons[row.original.status];
@@ -141,7 +143,7 @@ const statusColumn: ColumnDef<ExtendedReport> = {
 			icon: StatusIcons[status],
 		})),
 		placeholder: "Status",
-		filterType: "select",
+		filterType: "multiselect",
 	},
 };
 

--- a/apps/web/src/app/(app)/admin/reports/data-display/reports-list.tsx
+++ b/apps/web/src/app/(app)/admin/reports/data-display/reports-list.tsx
@@ -41,6 +41,17 @@ import { createColumns, type ExtendedReport } from "./columns";
 
 const PAGE_SIZE = 50;
 
+const DEFAULT_STATUS_FILTER: ColumnFiltersState = [
+	{
+		id: "status",
+		value: {
+			filterType: "multiselect",
+			operator: "in",
+			value: ["PENDING_APPROVAL", "ACCEPTED"] satisfies ReportStatus[],
+		},
+	},
+];
+
 const SERVER_SORT_FIELDS = [
 	"createdAt",
 	"lastUpdatedAt",
@@ -64,7 +75,7 @@ function buildReportListSorting(
 }
 
 type AdminFilterRule =
-	| { field: "status"; op: "is" | "isNot"; value: ReportStatus }
+	| { field: "status"; op: "in" | "notIn"; value: ReportStatus[] }
 	| { field: "ownerId"; op: "is" | "isNot"; value: string }
 	| { field: "costUnitId"; op: "in" | "notIn"; value: string[] }
 	| { field: "createdAt"; op: "between"; value: { start: Date; end: Date } };
@@ -77,11 +88,15 @@ function buildReportListFilters(
 	const rules: AdminFilterRule[] = [];
 
 	for (const filter of columnFilters) {
-		if (filter.id === "status" && isSelectFilter(filter.value)) {
+		if (
+			filter.id === "status" &&
+			isMultiSelectFilter(filter.value) &&
+			filter.value.value.length > 0
+		) {
 			rules.push({
 				field: "status",
-				op: filter.value.operator === "is" ? "is" : "isNot",
-				value: filter.value.value as ReportStatus,
+				op: filter.value.operator === "in" ? "in" : "notIn",
+				value: filter.value.value as ReportStatus[],
 			});
 		}
 
@@ -121,7 +136,9 @@ function buildReportListFilters(
 
 export function ReportsList() {
 	const [page, setPage] = useState<number>(1);
-	const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+	const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(
+		DEFAULT_STATUS_FILTER,
+	);
 	const [grouping, setGrouping] = useState<string[]>([]);
 	const [sorting, setSorting] = useState<SortingState>([]);
 	const [rowSelection, setRowSelection] = useState<RowSelectionState>({});

--- a/apps/web/src/server/modules/report/report.query.ts
+++ b/apps/web/src/server/modules/report/report.query.ts
@@ -268,7 +268,9 @@ export function buildReportListWhere({
 	userId,
 }: ReportListWhereInput): Prisma.ReportWhereInput {
 	const base: Prisma.ReportWhereInput =
-		scope === "own" ? { organizationId, ownerId: userId } : { organizationId };
+		scope === "own"
+			? { organizationId, ownerId: userId }
+			: { organizationId, status: { not: ReportStatus.DRAFT } };
 
 	if (!filters) {
 		return base;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hide other users’ draft reports from admin views and focus the admin list on items needing action. Admin “all” queries now exclude `DRAFT`, and the default status filter shows `PENDING_APPROVAL` and `ACCEPTED`.

- **Bug Fixes**
  - Exclude `DRAFT` from admin “all” queries at the DB layer (`status: { not: DRAFT }`).
  - Remove `DRAFT` from admin status filter options.

- **New Features**
  - Switch status filter to multiselect with “in/notIn” operators.
  - Default admin list to `PENDING_APPROVAL` and `ACCEPTED` on load.

<sup>Written for commit 0d27e58fc2703007d347ee60137fb70138b0e376. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/zemio-co/zemio/pull/173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

